### PR TITLE
Added en empty search result page

### DIFF
--- a/org.scala.tools.eclipse.search/plugin.xml
+++ b/org.scala.tools.eclipse.search/plugin.xml
@@ -1,18 +1,29 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?eclipse version="3.2"?>
 <plugin>
+
   <!-- Search pages extension point -->
   <extension point="org.eclipse.search.searchPages">
     <!-- When we're ready we need to set showScopeSection to true. -->
     <page
-         id="org.scala.tools.eclipse.search.ui.ScalaSearchPage"
+         id="org.scala.tools.eclipse.search.ui.SearchPage"
          label="Scala Search"
          sizeHint="250,160"
          tabPosition="1"
          extensions="scala:90"
          enabled="true"
          showScopeSection="false"
-         class="org.scala.tools.eclipse.search.ui.ScalaSearchPage">
+         class="org.scala.tools.eclipse.search.ui.SearchPage">
     </page>
   </extension>
+
+  <!-- Search Results panel extension point -->
+  <extension point="org.eclipse.search.searchResultViewPages">
+    <viewPage
+             id="org.scala.tools.eclipse.search.ui.SearchResultPage"
+             searchResultClass="org.scala.tools.eclipse.search.ui.SearchResult"
+             class="org.scala.tools.eclipse.search.ui.SearchResultPage">
+    </viewPage>
+  </extension>
+
 </plugin>

--- a/org.scala.tools.eclipse.search/src/org/scala/tools/eclipse/search/ui/SearchPage.scala
+++ b/org.scala.tools.eclipse.search/src/org/scala/tools/eclipse/search/ui/SearchPage.scala
@@ -23,7 +23,7 @@ import org.eclipse.swt.events.ModifyEvent
  * This is the page that is rendered in the Eclipse search dialog. It is 
  * Hooked into Eclipse through the SearchPage extension point.
  */
-class ScalaSearchPage extends DialogPage with ISearchPage with HasLogger {
+class SearchPage extends DialogPage with ISearchPage with HasLogger {
 
   /**
    * This is invoked when the user presses the search button.

--- a/org.scala.tools.eclipse.search/src/org/scala/tools/eclipse/search/ui/SearchResult.scala
+++ b/org.scala.tools.eclipse.search/src/org/scala/tools/eclipse/search/ui/SearchResult.scala
@@ -1,0 +1,46 @@
+package org.scala.tools.eclipse.search.ui
+
+import org.eclipse.jface.resource.ImageDescriptor
+import org.eclipse.search.ui.ISearchQuery
+import org.eclipse.search.ui.text.AbstractTextSearchResult
+import org.eclipse.search.ui.text.IEditorMatchAdapter
+import org.eclipse.search.ui.text.IFileMatchAdapter
+
+/**
+ * Represents the result of executing a search query against Scala
+ * files.
+ */
+class SearchResult extends AbstractTextSearchResult {
+
+  /**
+   * An implementation of IEditorMatchAdapter appropriate for this search result.
+   */
+  def getEditorMatchAdapter(): IEditorMatchAdapter = ???
+
+  /**
+   * An implementation of IFileMatchAdapter appropriate for this search result.
+   */
+  def getFileMatchAdapter(): IFileMatchAdapter = ???
+
+  /**
+   * The image descriptor for the given ISearchResult.
+   */
+  def getImageDescriptor(): ImageDescriptor = ???
+
+  /**
+   * A user readable label for this search result. The label is typically used in the result view
+   * and should contain the search query string and number of matches.
+   */
+  def getLabel(): String = "Haven't implemented yet"
+
+  /**
+   * The query that produced this search result.
+   */
+  def getQuery(): ISearchQuery = ???
+
+  /**
+   * A tooltip to be used when this search result is shown in the UI.
+   */
+  def getTooltip(): String = "Haven't implemented yet"
+
+}

--- a/org.scala.tools.eclipse.search/src/org/scala/tools/eclipse/search/ui/SearchResultPage.scala
+++ b/org.scala.tools.eclipse.search/src/org/scala/tools/eclipse/search/ui/SearchResultPage.scala
@@ -1,0 +1,39 @@
+package org.scala.tools.eclipse.search.ui
+
+import org.eclipse.jface.viewers.TableViewer
+import org.eclipse.jface.viewers.TreeViewer
+import org.eclipse.search.ui.text.AbstractTextSearchViewPage
+
+/**
+ * The page that is responsible for displaying the results of executing
+ * a scala search query.
+ */
+class SearchResultPage extends AbstractTextSearchViewPage {
+
+  /**
+   *  This method is called whenever all elements have been removed from the view.
+   */
+  def clear(): Unit = ???
+
+  /**
+   *  This method is called whenever the set of matches for the given elements changes.
+   */
+  def elementsChanged(elements: Array[Object]): Unit = ???
+
+  /**
+   * Invoked if the results are to be shown in a table.
+   */
+  def configureTableViewer(table: TableViewer): Unit = {
+    // TODO: Set up a content provider for the table.
+    ???
+  }
+
+  /**
+   * Invoked if the results are to be shown in a tree view
+   */
+  def configureTreeViewer(tree: TreeViewer): Unit = {
+    // TODO: Set up a content provider for the tree view.
+    ???
+  }
+
+}


### PR DESCRIPTION
By using the proper Eclipse extension point I've hooked our own
custom search result page into the search results view. The view
doesn't do anything and only contains "fake" implementations of the
methods necessary to make the compiler happy.

When we're able to execute queries and actually produce proper
search results we can finish the implementations.

This fixes #4
