### PR TITLE
Cleaned up profiles in POM

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Building
 
 The build is configured using maven so you build by invoking the following:
 
-    mvn -P scala-ide-master-scala-trunk clean package
+    mvn clean package
     
 Running it
 ----------
@@ -25,4 +25,4 @@ This adds the run configuration `Eclipse Application with Equinox Weaving`.
 Links
 -----
 
-- [Jenkins Job](https://jenkins.scala-ide.org:8496/jenkins/job/scala-search-nightly-2.1-2.10/)
+- [Jenkins Job](https://jenkins.scala-ide.org:8496/jenkins/view/Plugins%20%28Scala%20IDE%29/job/scala-search-nightly-master-2.10/?)

--- a/pom.xml
+++ b/pom.xml
@@ -43,42 +43,18 @@
     <repo.ajdt>${repo.ajdt.indigo}</repo.ajdt>
 
     <!-- some default values, can be overwritten by profiles -->
-    <scala.version>2.9.3-SNAPSHOT</scala.version>
-    <version.suffix>2_09</version.suffix>
-    <scala.version.short>2.9</scala.version.short>
+    <scala.version>2.10.1-SNAPSHOT</scala.version>
+    <version.suffix>2_10</version.suffix>
+    <scala.version.short>2.10</scala.version.short>
     <version.tag>local</version.tag>
-    <repo.scala-ide>${repo.scala-ide.root}/releases-29/stable/site</repo.scala-ide>
+    <repo.scala-ide>${repo.scala-ide.root}/nightly-update-master-trunk</repo.scala-ide>
     <junit.version>4.10</junit.version>
    </properties>
 
   <profiles>
     <profile>
       <!-- this is the default profile, using the stable builds-->
-      <id>scala-ide-2.0-scala-2.9</id>
-    </profile>
-    <profile>
-      <!-- 2.0.x Scala IDE with Scala 2.9 -->
-      <id>scala-ide-2.0.x-scala-2.9</id>
-      <properties>
-        <repo.scala-ide>${repo.scala-ide.root}/nightly-update-2-0-x-29x</repo.scala-ide>
-      </properties>
-    </profile>
-    <profile>
-      <!-- nightly Scala IDE with Scala 2.9 -->
-      <id>scala-ide-master-scala-2.9</id>
-      <properties>
-        <repo.scala-ide>${repo.scala-ide.root}/nightly-update-master-29x</repo.scala-ide>
-      </properties>
-    </profile>
-    <profile>
-      <!-- nightly Scala IDE with Scala trunk -->
       <id>scala-ide-master-scala-trunk</id>
-      <properties>
-        <scala.version>2.10.0-SNAPSHOT</scala.version>
-        <version.suffix>2_10</version.suffix>
-        <scala.version.short>2.10</scala.version.short>
-        <repo.scala-ide>${repo.scala-ide.root}/nightly-update-master-trunk</repo.scala-ide>
-      </properties>
     </profile>
 
     <profile>


### PR DESCRIPTION
- No need to have a profile for Scala 2.9. Cleaning up this makes it easier to
  build the plugin as no profile need to be passed.
- Use Scala 2.10.1-SNAPSHOT for building, since this is the Scala version used
  by the IDE nightlies, and you don't want to be subject to binary incompatibilities
  (keep in mind that the Scala compiler jar isn't binary compatible).
- Updated link to the Jenkins job.

I need this commit to complete #9.

Review by @mads379
