### PR TITLE
Added build profile for Scala IDE for Eclipse Juno

### DIFF
--- a/org.scala.tools.eclipse.search/META-INF/MANIFEST.MF
+++ b/org.scala.tools.eclipse.search/META-INF/MANIFEST.MF
@@ -10,7 +10,7 @@ Require-Bundle:
  org.eclipse.core.runtime,
  org.eclipse.debug.ui,
  org.eclipse.help,
- org.eclipse.jdt.core;bundle-version="[3.6.0,3.7.10)",
+ org.eclipse.jdt.core;bundle-version="[3.6.0,4.0.0)",
  org.eclipse.jdt.debug.ui,
  org.eclipse.jdt.junit,
  org.eclipse.jdt.launching,

--- a/pom.xml
+++ b/pom.xml
@@ -22,13 +22,10 @@
   <properties>
     <encoding>UTF-8</encoding>
     <!-- p2 repositories location -->
-    <repo.eclipse.indigo>http://download.eclipse.org/releases/indigo/</repo.eclipse.indigo>
-    <repo.eclipse.juno>http://download.eclipse.org/releases/juno/</repo.eclipse.juno>
-    <repo.ajdt.indigo>http://download.eclipse.org/tools/ajdt/37/dev/update</repo.ajdt.indigo>
     <repo.scala-ide.root>http://download.scala-ide.org</repo.scala-ide.root>
 
     <!-- fixed versions -->
-    <tycho.version>0.15.0</tycho.version>
+    <tycho.version>0.16.0</tycho.version>
     <scala.plugin.version>3.0.2</scala.plugin.version>
 
     <!-- tycho test related -->
@@ -37,13 +34,14 @@
     <tycho.test.weaving>-XX:+UnlockDiagnosticVMOptions -XX:+UnsyncloadClass -Dosgi.classloader.lock=classname</tycho.test.weaving>
     <tycho.test.jvmArgs>-Xmx800m -XX:MaxPermSize=256m -Dsdtcore.headless ${tycho.test.weaving} ${tycho.test.OSspecific}</tycho.test.jvmArgs>
 
-    <!-- dependencies repos -->
+    <!-- dependencies repos (default for Eclipse Indigo) -->
     <eclipse.codename>indigo</eclipse.codename>
-    <repo.eclipse>${repo.eclipse.indigo}</repo.eclipse>
-    <repo.ajdt>${repo.ajdt.indigo}</repo.ajdt>
+    <repo.eclipse>http://download.eclipse.org/releases/indigo/</repo.eclipse>
+    <repo.ajdt>http://download.eclipse.org/tools/ajdt/37/dev/update</repo.ajdt>
+    <weaving.hook.plugin.version>1.0.200.I20120427-0800</weaving.hook.plugin.version>
 
     <!-- some default values, can be overwritten by profiles -->
-    <scala.version>2.10.1-SNAPSHOT</scala.version>
+    <scala.version>2.10.2-SNAPSHOT</scala.version>
     <version.suffix>2_10</version.suffix>
     <scala.version.short>2.10</scala.version.short>
     <version.tag>local</version.tag>
@@ -53,8 +51,21 @@
 
   <profiles>
     <profile>
-      <!-- this is the default profile, using the stable builds-->
-      <id>scala-ide-master-scala-trunk</id>
+       <!-- Default values are for building against Eclipse Indigo-->
+      <id>indigo</id>
+    </profile>
+    
+    <profile>
+      <id>juno</id>
+      <properties>
+        <eclipse.codename>juno</eclipse.codename>
+        <repo.eclipse>http://download.eclipse.org/releases/juno/</repo.eclipse>
+        <repo.ajdt>http://download.eclipse.org/tools/ajdt/42/update</repo.ajdt>
+        <weaving.hook.plugin.version>1.0.200.v20120524-1707</weaving.hook.plugin.version>
+
+        <scala.version>2.10.1</scala.version>
+        <repo.scala-ide>http://download.scala-ide.org/sdk/e38/scala210/stable/site</repo.scala-ide>
+      </properties>
     </profile>
 
     <profile>
@@ -164,7 +175,7 @@
               <frameworkExtension>
                 <groupId>p2.osgi.bundle</groupId>
                 <artifactId>org.eclipse.equinox.weaving.hook</artifactId>
-                <version>1.0.200.I20120427-0800</version>
+                <version>${weaving.hook.plugin.version}</version>
               </frameworkExtension>
             </frameworkExtensions>
             <bundleStartLevel>


### PR DESCRIPTION
- Updated tycho version to 0.16.0.
- New `juno` profile for building the plug-in for
  the Scala IDE for Eclipse Juno (default values are
  for building the nightly Scala IDE for Eclipse Indigo)
- Updated default scala.version to:
  - 2.10.2-SNAPSHOT when building against the Scala IDE 4.0.x nightly.
  - 2.10.1 when building against the Scala IDE 3.0.

Both PR validator job should finally succeed (but we can't test this until tomorrow because it looks like we have an issue with our CI server). Hopefully, it will be good on Monday.
