### PR TITLE
Use project relative paths in index

### DIFF
--- a/org.scala.tools.eclipse.search.tests/src/org/scala/tools/eclipse/search/IndexTest.scala
+++ b/org.scala.tools.eclipse.search.tests/src/org/scala/tools/eclipse/search/IndexTest.scala
@@ -42,9 +42,28 @@ class IndexTest {
 
     val interestingNames = List("method", "methodOne", "methodTwo", "methodThree")
 
-    val results = index.occurrencesInFile(source.file.file, source.getUnderlyingResource().getProject()).filter( x => interestingNames.contains(x.word))
+    val results = index.occurrencesInFile(
+        source.workspaceFile.getProjectRelativePath(),
+        source.scalaProject.underlying).filter( x => interestingNames.contains(x.word))
 
     assertEquals("Should be able to store and retrieve occurrences", expected, results)
+  }
+
+  @Test def deleteOccurrences() {
+
+    val index = new Index(INDEX_DIR)
+    val indexer = new SourceIndexer(index)
+    val source = scalaCompilationUnit(mkPath("org","example","ScalaClass.scala"))
+    indexer.indexScalaFile(source)
+
+    index.removeOccurrencesFromFile(source.workspaceFile.getProjectRelativePath(), source.scalaProject.underlying)
+
+    val results = index.occurrencesInFile(
+        source.workspaceFile.getProjectRelativePath(),
+        source.scalaProject.underlying)
+
+    assertEquals("Index should not contain any occurrence in file", 0, results.size)
+
   }
 
 }

--- a/org.scala.tools.eclipse.search/src/org/scala/tools/eclipse/search/indexing/Occurrence.scala
+++ b/org.scala.tools.eclipse.search/src/org/scala/tools/eclipse/search/indexing/Occurrence.scala
@@ -18,9 +18,10 @@ case object Reference extends OccurrenceKind
 
 object LuceneFields {
   val WORD            = "word"
-  val FILE            = "file"
+  val PATH            = "path"
   val OFFSET          = "offset"
   val OCCURRENCE_KIND = "occurrenceKind"
+  val PROJECT_NAME    = "project"
 }
 
 /**

--- a/org.scala.tools.eclipse.search/src/org/scala/tools/eclipse/search/indexing/SourceIndexer.scala
+++ b/org.scala.tools.eclipse.search/src/org/scala/tools/eclipse/search/indexing/SourceIndexer.scala
@@ -38,7 +38,7 @@ class SourceIndexer(index: Index) extends HasLogger {
    */
   def indexScalaFile(sf: ScalaSourceFile): Unit = {
     logger.debug(s"Indexing document: ${sf.file.path}")
-    index.removeOccurrencesFromFile(sf.file.file, sf.getUnderlyingResource().getProject())
+    index.removeOccurrencesFromFile(sf.workspaceFile.getProjectRelativePath(), sf.scalaProject.underlying)
     OccurrenceCollector.findOccurrences(sf).fold(
       fail => logger.debug(fail),
       occurrences => index.addOccurrences(occurrences, sf.getUnderlyingResource().getProject()))


### PR DESCRIPTION
We now rely on a combination of project name and a project
relative path to keep track of files in the Index.

Fix #1001632
