### PR TITLE
1001621 Improved tree traversal

### DIFF
--- a/org.scala.tools.eclipse.search.tests/src/org/scala/tools/eclipse/search/OccurrenceCollectorTest.scala
+++ b/org.scala.tools.eclipse.search.tests/src/org/scala/tools/eclipse/search/OccurrenceCollectorTest.scala
@@ -68,5 +68,18 @@ class OccurrenceCollectorTest {
     }
   }
 
+  @Test def stringInterpolation() {
+    doWithOccurrencesInUnit("org","example","StringInterpolation.scala") { occurrences =>
+      val x = occurrenceFor("x", occurrences)
+      assertEquals("Should be 2 occurrences of x %s".format(x), 2, x.size)
+    }
+  }
+
+  @Test def annotationsOnMethods() {
+    doWithOccurrencesInUnit("org","example", "Annotations.scala") { occurrences =>
+      val x = occurrenceFor("IOException", occurrences)
+      assertEquals("Should be 1 occurrences of IOException %s".format(x), 1, x.size)
+    }
+  }
 
 }

--- a/org.scala.tools.eclipse.search.tests/test-workspace/aProject/src/org/example/Annotations.scala
+++ b/org.scala.tools.eclipse.search.tests/test-workspace/aProject/src/org/example/Annotations.scala
@@ -1,0 +1,7 @@
+package org.example
+
+import java.io.IOException
+
+object Test {
+  @throws(classOf[IOException]) def test() = {}
+}

--- a/org.scala.tools.eclipse.search.tests/test-workspace/aProject/src/org/example/StringInterpolation.scala
+++ b/org.scala.tools.eclipse.search.tests/test-workspace/aProject/src/org/example/StringInterpolation.scala
@@ -1,0 +1,5 @@
+package org.example
+
+object StringInterpolation {
+  def foo(x: String) = s"Hi there, ${x}"
+}

--- a/org.scala.tools.eclipse.search/src/org/scala/tools/eclipse/search/indexing/OccurrenceCollector.scala
+++ b/org.scala.tools.eclipse.search/src/org/scala/tools/eclipse/search/indexing/OccurrenceCollector.scala
@@ -39,14 +39,23 @@ object OccurrenceCollector extends HasLogger {
 
           case Select(rest,name) if !isSynthetic(pc)(t, name.toString) =>
             occurrences += Occurrence(name.toString, file, t.pos.point, Reference)
-            super.traverse(rest) // recurse in the case of chained selects: foo.baz.bar
+            traverse(rest) // recurse in the case of chained selects: foo.baz.bar
 
           // Method definitions
-          case DefDef(_, name, _, _, _, body) if !isSynthetic(pc)(t, name.toString) =>
+          case DefDef(mods, name, _, args, _, body) if !isSynthetic(pc)(t, name.toString) =>
             occurrences += Occurrence(name.toString, file, t.pos.point, Declaration)
-            super.traverse(body)
+            traverseTrees(mods.annotations)
+            traverseTreess(args)
+            traverse(body)
 
-          case _ => super.traverse(t)
+          // Val's and arguments.
+          case ValDef(_, name, tpt, rhs) =>
+            occurrences += Occurrence(name.toString, file, t.pos.point, Declaration)
+            traverse(tpt)
+            traverse(rhs)
+
+          case _ =>
+            super.traverse(t)
         }
       }
     }


### PR DESCRIPTION
This fixes three issues
- The code used super.traverse to recurse the trees. This was wrong
  as it would skip one 'layer' of nodes.
- Traverse the argument list of DefDef's
- Store occurrences in ValDefs

So it turned out that the failure that was seen with the string
interpolation test had nothing to do with string interpolation.

Originally it only found one occurrence of `x` in the following
example.

```
def foo(x: String) = s"Hi there, ${x}"
```

I assumed that the `x` that was missing was the one inside of the
string interpolation, but actually it was the argument. Ups.

Fix #1001621
