### PR TITLE
Record occurrences of constructors

### DIFF
--- a/org.scala.tools.eclipse.search.tests/src/org/scala/tools/eclipse/search/indexing/OccurrenceCollectorTest.scala
+++ b/org.scala.tools.eclipse.search.tests/src/org/scala/tools/eclipse/search/indexing/OccurrenceCollectorTest.scala
@@ -82,4 +82,34 @@ class OccurrenceCollectorTest {
     }
   }
 
+  @Test def recordsOccurrencesOfSyntheticEmptyConstructor() {
+    doWithOccurrencesInUnit("org", "example", "SyntheticEmptyConstructor.scala") { occurrences =>
+      val x = occurrenceFor("<init>", occurrences).filter(_.occurrenceKind == Declaration)
+      assertEquals("Should find 1 synthetic empty constructor", 1, x.size)
+    }
+  }
+
+  @Test def recordsOccurrencesOfSyntheticConstructor() {
+    doWithOccurrencesInUnit("org", "example", "SyntheticConstructor.scala") { occurrences =>
+      val x = occurrenceFor("<init>", occurrences).filter(_.occurrenceKind == Declaration)
+      assertEquals("Should find 1 synthetic constructor", 1, x.size)
+    }
+  }
+
+  @Test def recordsOccurrencesOfExplicitConstructor() {
+    doWithOccurrencesInUnit("org", "example", "ExplicitConstructor.scala") { occurrences =>
+      val x = occurrenceFor("<init>", occurrences).filter(_.occurrenceKind == Declaration)
+      assertEquals("Should find 2 constructors", 2, x.size)
+    }
+  }
+
+  @Test def findInvocationsOfConstructors() {
+    doWithOccurrencesInUnit("org", "example", "ConstructorInvocations.scala") { occurrences =>
+      // we expect 3 here because the constructors created by the compiler calls super.<init>.
+      // The compiler generates a constructor for the class and the companion object.
+      val x = occurrenceFor("<init>", occurrences).filter(_.occurrenceKind == Reference)
+      assertEquals("Should find 3 constructors", 3, x.size)
+    }
+  }
+
 }

--- a/org.scala.tools.eclipse.search.tests/test-workspace/aProject/src/org/example/ConstructorInvocations.scala
+++ b/org.scala.tools.eclipse.search.tests/test-workspace/aProject/src/org/example/ConstructorInvocations.scala
@@ -1,0 +1,9 @@
+class ConstructorInvocations {
+
+}
+
+object ConstructorInvocations {
+
+  def apply() = new ConstructorInvocations
+
+}

--- a/org.scala.tools.eclipse.search.tests/test-workspace/aProject/src/org/example/ExplicitConstructor.scala
+++ b/org.scala.tools.eclipse.search.tests/test-workspace/aProject/src/org/example/ExplicitConstructor.scala
@@ -1,0 +1,5 @@
+class ExplicitConstructor {
+
+  def this(s: String) = this
+
+}

--- a/org.scala.tools.eclipse.search.tests/test-workspace/aProject/src/org/example/SyntheticConstructor.scala
+++ b/org.scala.tools.eclipse.search.tests/test-workspace/aProject/src/org/example/SyntheticConstructor.scala
@@ -1,0 +1,1 @@
+class SyntheticConstructor(x: String) {}

--- a/org.scala.tools.eclipse.search.tests/test-workspace/aProject/src/org/example/SyntheticEmptyConstructor.scala
+++ b/org.scala.tools.eclipse.search.tests/test-workspace/aProject/src/org/example/SyntheticEmptyConstructor.scala
@@ -1,0 +1,1 @@
+class SynthethicEmptyConstructor {}

--- a/org.scala.tools.eclipse.search/src/org/scala/tools/eclipse/search/indexing/OccurrenceCollector.scala
+++ b/org.scala.tools.eclipse.search/src/org/scala/tools/eclipse/search/indexing/OccurrenceCollector.scala
@@ -77,8 +77,7 @@ object OccurrenceCollector extends HasLogger {
 
   private def isSynthetic(pc: ScalaPresentationCompiler)
                          (tree: pc.Tree, name: String): Boolean = {
-    val syntheticNames = Set("<init>")
-    tree.pos == pc.NoPosition || syntheticNames.contains(name)
+    tree.pos == pc.NoPosition
   }
 
 }


### PR DESCRIPTION
The occurrence collector now records occurrences of constructors;
that is both definitions and invocations. Test have been added for
the various ways you can define constructors.

Fix #1001622
