### PR TITLE
#1001662 API for getting symbol at location

### DIFF
--- a/org.scala.tools.eclipse.search.tests/src/org/scala/tools/eclipse/search/TestsSuite.scala
+++ b/org.scala.tools.eclipse.search.tests/src/org/scala/tools/eclipse/search/TestsSuite.scala
@@ -5,16 +5,18 @@ import org.junit.runners.Suite
 
 import org.scala.tools.eclipse.search.jobs._
 import org.scala.tools.eclipse.search.indexing._
+import org.scala.tools.eclipse.search.searching._
 
 
 @RunWith(classOf[Suite])
 @Suite.SuiteClasses(Array(
-  classOf[OccurrenceCollectorTest],
-  classOf[LuceneIntegrationTest],
-  classOf[IndexTest],
-  classOf[UsingTest],
-  classOf[IndexJobManagerTest],
-  classOf[ProjectIndexJobTest],
-  classOf[ProjectChangeObserverTest]
+  classOf[OccurrenceCollectorTest]
+  ,classOf[LuceneIntegrationTest]
+  ,classOf[IndexTest]
+  ,classOf[UsingTest]
+  ,classOf[IndexJobManagerTest]
+  ,classOf[ProjectIndexJobTest]
+  ,classOf[ProjectChangeObserverTest]
+  ,classOf[SearchPresentationCompilerTest]
 ))
 class TestsSuite {}

--- a/org.scala.tools.eclipse.search.tests/src/org/scala/tools/eclipse/search/searching/SearchPresentationCompilerTest.scala
+++ b/org.scala.tools.eclipse.search.tests/src/org/scala/tools/eclipse/search/searching/SearchPresentationCompilerTest.scala
@@ -1,0 +1,33 @@
+package org.scala.tools.eclipse.search.searching
+
+import scala.tools.eclipse.testsetup.TestProjectSetup
+import org.junit.Test
+import org.scala.tools.eclipse.search.TestUtil
+import org.junit.Assert._
+
+class SearchPresentationCompilerTest {
+
+  import SearchPresentationCompilerTest._
+  import SearchPresentationCompiler._
+
+  @Test def canGetSymbolAtLocation {
+    val unit = scalaCompilationUnit(mkPath("org", "example", "ExampleWithSymbol.scala"))
+    unit.withSourceFile { (cu, pc) =>
+      val symbol = pc.symbolAt(Location(unit, 34), cu).get
+      assertEquals("x", pc.askOption( () => symbol.nameString ).get)
+    }(fail("withSourceFile call failed unexpectedly"))
+  }
+
+  @Test def noneIfAskedForWrongLocation {
+    val unit = scalaCompilationUnit(mkPath("org", "example", "ExampleWithSymbol.scala"))
+    unit.withSourceFile { (cu, pc) =>
+      val symbol = pc.symbolAt(Location(unit, 108), cu) // 108 doesn't exist.
+      assertEquals(true, symbol.isEmpty)
+    }(fail("withSourceFile call failed unexpectedly"))
+  }
+
+}
+
+object SearchPresentationCompilerTest
+  extends TestProjectSetup("SearchPresentationCompilerTest", bundleName= "org.scala.tools.eclipse.search.tests") 
+     with TestUtil

--- a/org.scala.tools.eclipse.search.tests/test-workspace/SearchPresentationCompilerTest/.classpath
+++ b/org.scala.tools.eclipse.search.tests/test-workspace/SearchPresentationCompilerTest/.classpath
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="con" path="org.scala-ide.sdt.launching.SCALA_CONTAINER"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.6"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/org.scala.tools.eclipse.search.tests/test-workspace/SearchPresentationCompilerTest/.project
+++ b/org.scala.tools.eclipse.search.tests/test-workspace/SearchPresentationCompilerTest/.project
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>SearchPresentationCompilerTest</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.scala-ide.sdt.core.scalabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.scala-ide.sdt.core.scalanature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/org.scala.tools.eclipse.search.tests/test-workspace/SearchPresentationCompilerTest/src/org/example/ExampleWithSymbol.scala
+++ b/org.scala.tools.eclipse.search.tests/test-workspace/SearchPresentationCompilerTest/src/org/example/ExampleWithSymbol.scala
@@ -1,0 +1,3 @@
+class ExampleWithSymbol {
+  val x: Int = 42
+}

--- a/org.scala.tools.eclipse.search/src/org/scala/tools/eclipse/search/searching/Location.scala
+++ b/org.scala.tools.eclipse.search/src/org/scala/tools/eclipse/search/searching/Location.scala
@@ -1,0 +1,6 @@
+package org.scala.tools.eclipse.search.searching
+
+import scala.tools.eclipse.javaelements.ScalaSourceFile
+import scala.tools.eclipse.InteractiveCompilationUnit
+
+case class Location(cu: InteractiveCompilationUnit, offset: Int)

--- a/org.scala.tools.eclipse.search/src/org/scala/tools/eclipse/search/searching/SearchPresentationCompiler.scala
+++ b/org.scala.tools.eclipse.search/src/org/scala/tools/eclipse/search/searching/SearchPresentationCompiler.scala
@@ -1,0 +1,45 @@
+package org.scala.tools.eclipse.search.searching
+
+import scala.tools.eclipse.ScalaPresentationCompiler
+import scala.reflect.internal.util.SourceFile
+import scala.tools.nsc.interactive.Response
+import scala.reflect.internal.util.OffsetPosition
+import scala.tools.eclipse.logging.HasLogger
+
+object SearchPresentationCompiler extends HasLogger {
+
+  /**
+   * Encapsulates PC logic. Makes it easier to control where the compiler data
+   * structures are used and thus make sure that we conform to the synchronization
+   * policy of the presentation compiler.
+   */
+  implicit class SearchPresentationCompiler(val pc: ScalaPresentationCompiler) {
+
+    /**
+     * Get the symbol of the entity at a given location in a file.
+     *
+     * The source file needs to be loaded before invoking this method. This can be
+     * achieved by invoking `pc.askReload(..)`.
+     */
+    def symbolAt[A](loc: Location, cu: SourceFile): Option[pc.Symbol] = {
+      val typed = new Response[pc.Tree]
+      val pos = new OffsetPosition(cu, loc.offset)
+      pc.askTypeAt(pos, typed)
+      typed.get.fold(
+        tree => filterNoSymbols(tree.symbol),
+        err => {
+          logger.debug(err)
+          None
+        })
+    }
+
+    private def filterNoSymbols(sym: pc.Symbol): Option[pc.Symbol] = {
+      if (sym == null || sym == pc.NoSymbol) {
+        None
+      } else {
+        Some(sym)
+      }
+    }
+
+  }
+}


### PR DESCRIPTION
API for getting symbol at location

This commit provides an API for getting the symbol at a specific location in a file. It introduces an implicit value class that is used to add functionality to the presentation compiler.

A small test case has been provided

Fixes #1001662
