### PR TITLE
IndexJobManager does no longer inherit from Index

### DIFF
--- a/org.scala.tools.eclipse.search/src/org/scala/tools/eclipse/search/Lifecycle.scala
+++ b/org.scala.tools.eclipse.search/src/org/scala/tools/eclipse/search/Lifecycle.scala
@@ -21,8 +21,6 @@ package org.scala.tools.eclipse.search
  * }}}
  */
 trait Lifecycle {
-
-  def startup(): Unit = ()
-  def shutdown(): Unit = ()
-
+  def startup(): Unit
+  def shutdown(): Unit
 }

--- a/org.scala.tools.eclipse.search/src/org/scala/tools/eclipse/search/Observing.scala
+++ b/org.scala.tools.eclipse.search/src/org/scala/tools/eclipse/search/Observing.scala
@@ -5,7 +5,7 @@ import org.eclipse.core.resources.ResourcesPlugin
 
 class Observing(listener: IResourceChangeListener) {
 
-  def stop: Unit = {
+  def stop(): Unit = {
     ResourcesPlugin.getWorkspace().removeResourceChangeListener(listener)
   }
 


### PR DESCRIPTION
There is no need for `IndexJobManager` to inherit from `Index`. Using
composition here is better and reduces coupling.

This is a follow-up on the discussion that happened in
https://github.com/scala-ide/scala-search/pull/24

@mads379, how do you like it?
