### PR TITLE
Provide an API for comparing method symbols

### DIFF
--- a/org.scala.tools.eclipse.search.tests/src/org/scala/tools/eclipse/search/SourceCreator.scala
+++ b/org.scala.tools.eclipse.search.tests/src/org/scala/tools/eclipse/search/SourceCreator.scala
@@ -1,0 +1,153 @@
+package org.scala.tools.eclipse.search
+
+import scala.tools.eclipse.javaelements.ScalaCompilationUnit
+import scala.tools.eclipse.EclipseUserSimulator
+import org.eclipse.core.runtime.NullProgressMonitor
+import org.junit.Assert._
+import org.scala.tools.eclipse.search.searching.SearchPresentationCompiler._
+import org.scala.tools.eclipse.search.searching.Location
+import org.eclipse.jdt.core.JavaCore
+import org.eclipse.jdt.core.IClasspathEntry
+
+trait SourceCreator {
+
+  private final val CaretMarker = '|'
+
+  case class ScalaDocument(unit: ScalaCompilationUnit, markers: Seq[Int]) {
+
+    def expectedSymbolNamed(nameOpt: Option[String]): Unit = {
+      unit.withSourceFile { (sf, pc) =>
+        val spc = SearchPresentationCompiler(pc)
+        val symbol = spc.symbolAt(Location(unit, markers.head), sf)
+
+        import spc._
+        symbol match {
+          case FoundSymbol(sym) => assertEquals(nameOpt, Some(sym.nameString))
+          case _ => assertEquals(nameOpt, None)
+        }
+      } (fail("Couldn't get Scala source file"))
+    }
+
+    def expectedNoSymbol: Unit = {
+      unit.withSourceFile { (sf, pc) =>
+        val spc = SearchPresentationCompiler(pc)
+        val symbol = spc.symbolAt(Location(unit, markers.head), sf)
+
+        import spc._
+        symbol match {
+          case MissingSymbol => assertTrue(true)
+          case x => fail(s"Expected NoSymbol but found ${x}")
+        }
+      } (fail("Couldn't get Scala source file"))
+    }
+
+    def expectedTypeError: Unit = {
+      unit.withSourceFile { (sf, pc) =>
+        val spc = SearchPresentationCompiler(pc)
+        val symbol = spc.symbolAt(Location(unit, markers.head), sf)
+
+        import spc._
+        symbol match {
+          case NotTypeable => assertTrue(true)
+          case x => fail(s"Expected NotTypeable but found ${x}")
+        }
+      } (fail("Couldn't get Scala source file"))
+    }
+
+    /**
+     * Creates an assertion to see if the symbol under the cursor at the
+     * two markers in the file is the same or not.
+     *
+     * Note: The document has to be created with two markers (i.e. |)
+     */
+    def isSameMethod(expected: Boolean): Unit = {
+      unit.withSourceFile { (sf, pc) =>
+        val spc = SearchPresentationCompiler(pc)
+        import spc._
+        val s1 = spc.symbolAt(Location(unit, markers(0)), sf)
+        val s2 = spc.symbolAt(Location(unit, markers(1)), sf)
+        val isSame = (s1, s2) match {
+          case (FoundSymbol(sym1),FoundSymbol(sym2)) => spc.isSameMethod(sym1,sym2)
+          case (_,_) => false
+        }
+        assertEquals(expected, isSame)
+      }((fail("Couldn't get source file")))
+    }
+
+    def isSameMethodAs(other: ScalaDocument, expeced: Boolean = true) = {
+      unit.withSourceFile { (sf1 ,pc1) =>
+        val spc = SearchPresentationCompiler(pc1)
+        other.unit.withSourceFile { (sf2, pc2) =>
+          val spc2 = SearchPresentationCompiler(pc2)
+          val s1 = spc.symbolAt(Location(unit, markers.head), sf1)
+          val s2 = spc2.symbolAt(Location(other.unit, other.markers.head), sf2)
+          val isSame = (s1,s2) match {
+            case (spc.FoundSymbol(sym1),spc2.FoundSymbol(sym2)) => {
+              val imported = spc.importSymbol(spc2)(sym2)
+              spc.isSameMethod(sym1,imported)
+            }
+            case (_,_) => false
+          }
+          assertEquals(expeced, isSame)
+        }(fail("Couldn't get the other source file"))
+      }((fail("Couldn't get source file")))
+    }
+
+  }
+
+  class Project private (val name: String) {
+
+    import Project._
+
+    private val adhocSimulator = new EclipseUserSimulator
+    private var _sources: Seq[ScalaCompilationUnit] = Nil
+
+    val scalaProject = adhocSimulator.createProjectInWorkspace(name, true)
+
+    def source = _sources
+
+    def addProjectsToClasspath(others: Project*): Unit = {
+      var entries = new scala.collection.mutable.ArrayBuffer[IClasspathEntry]()
+
+      others.foreach { other =>
+        val sourceFolder = other.scalaProject.underlying.getFolder("/src");
+        val root = other.scalaProject.javaProject.getPackageFragmentRoot(sourceFolder);
+        entries += JavaCore.newSourceEntry(root.getPath());
+      }
+
+      val newClasspath = entries ++ scalaProject.javaProject.getRawClasspath()
+      scalaProject.javaProject.setRawClasspath(newClasspath.toArray, new NullProgressMonitor)
+    }
+
+    def create(name: String)(text: String): ScalaDocument = {
+
+      var cursors = List[Int]()
+
+      var offset = text.indexOf(CaretMarker)
+      while (offset != -1) {
+        cursors = cursors :+ offset
+        offset = text.indexOf(CaretMarker, offset+1)
+      }
+
+      if (cursors.isEmpty)
+        fail(s"There has to be atleast one marker '${CaretMarker}' in the source file")
+
+      val cleanedText = text.filterNot(_ == CaretMarker).mkString
+      val emptyPkg = adhocSimulator.createPackage("")
+      val unit = adhocSimulator.createCompilationUnit(emptyPkg, name, cleanedText.stripMargin).asInstanceOf[ScalaCompilationUnit]
+
+      unit +: _sources
+
+      ScalaDocument(unit, cursors)
+    }
+
+    def delete = {
+      scalaProject.underlying.delete(true, new NullProgressMonitor)
+    }
+  }
+
+  object Project {
+    def apply(name: String) = new Project(name)
+  }
+
+}

--- a/org.scala.tools.eclipse.search.tests/src/org/scala/tools/eclipse/search/searching/SearchPresentationCompilerTest.scala
+++ b/org.scala.tools.eclipse.search.tests/src/org/scala/tools/eclipse/search/searching/SearchPresentationCompilerTest.scala
@@ -1,36 +1,33 @@
 package org.scala.tools.eclipse.search.searching
 
-import scala.tools.eclipse.EclipseUserSimulator
-import scala.tools.eclipse.ScalaProject
-import scala.tools.eclipse.javaelements.ScalaCompilationUnit
-import scala.tools.eclipse.testsetup.TestProjectSetup
-import org.junit._
-import org.junit.Assert._
+import scala.tools.eclipse.testsetup.SDTTestUtils
+import org.junit.After
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.scala.tools.eclipse.search.SourceCreator
 import org.scala.tools.eclipse.search.TestUtil
+import SearchPresentationCompilerTest.Project
+import org.scala.tools.eclipse.search.FileChangeObserver
+import java.util.concurrent.CountDownLatch
+import org.eclipse.core.resources.IFile
+import org.junit.Ignore
 
 class SearchPresentationCompilerTest {
 
   import SearchPresentationCompilerTest._
   import SearchPresentationCompiler._
 
-  private final val CaretMarker = '|'
-
-  protected val simulator = new EclipseUserSimulator
-  private var project: ScalaProject = _ // A project is needed, otherwise we get NPE when using simulator.
-
-  @Before
-  def createProject() {
-    project = simulator.createProjectInWorkspace("search-presentation-compiler-test", true)
-  }
+  private val project = Project("SearchPresentationCompilerTest")
 
   @After
   def deleteProject() {
-    project.underlying.delete(true, null)
+    project.delete
   }
 
   @Test
   def canGetSymbolAtLocation {
-    document {"""
+    project.create("ExampleWithSymbol.scala") {"""
       class ExampleWithSymbol {
         val |x: Int = 42
       }
@@ -39,39 +36,405 @@ class SearchPresentationCompilerTest {
   }
 
   @Test
-  def noneIfAskedForWrongLocation {
-    document {"""
-      class ExampleWithSymbol {
+  def constructorDefinition {
+    project.create("ConstructorDefinition.scala") {"""
+      class A {
+        def th|is(x: String) {
+          this()
+        }
+      }
+    """} expectedSymbolNamed(Some("<init>"))
+  }
+
+  @Test
+  def constructorInvocation {
+    project.create("ConstructorReference.scala") {"""
+      class A {
+        def this(x: String) {
+          this()
+        }
+      }
+      object A {
+        ne|w A("test")
+      }
+    """} expectedSymbolNamed(Some("<init>"))
+  }
+
+  @Test
+  def noSymbolIfAskedForWrongLocation {
+    project.create("ExampleWithSymbol2.scala") {"""
+      class ExampleWithSymbol2 {
         val x: Int = 42
       }
       |
     """
-    } expectedSymbolNamed(None)
+    } expectedNoSymbol
   }
 
-  private def scalaSourceFile(code: String): ScalaCompilationUnit = {
-    val emptyPkg = simulator.createPackage("")
-    simulator.createCompilationUnit(emptyPkg, "A.scala", code.stripMargin).asInstanceOf[ScalaCompilationUnit]
-  }
-
-  private def document(text: String) = new {
-    def expectedSymbolNamed(nameOpt: Option[String]): Unit = {
-      val caret: Int = {
-        val offset = text.indexOf(CaretMarker)
-        if (offset == -1) fail(s"Could not locate caret position marker '${CaretMarker}' in test.")
-        offset
+  @Test
+  def notTypeableIfAskedForLocationWithTypeError {
+    project.create("ExampleWithSymbol3.scala") {"""
+      class ExampleWithSymbol3 {
+        def foo(x: String) = x
+        def bar(x: String) = invalid(fo|o(x))
       }
-      val cleanedText = text.filterNot(_ == CaretMarker).mkString
-      val cu = scalaSourceFile(cleanedText)
-      cu.withSourceFile { (sf, pc) =>
-        val symbol = pc.symbolAt(Location(cu, caret), sf)
-        assertEquals(nameOpt, symbol.map(_.nameString))
-      } (fail("Couldn't get Scala source file"))
-    }
+    """} expectedTypeError
+  }
+
+  @Test
+  def isSameMethod_withSameSymbol {
+    project.create("WithSameSymbol.scala") {"""
+      class WithSameSymbol {
+        def re|ve|rse(x: String) = x.reverse
+      }
+    """} isSameMethod(true)
+  }
+
+  @Test
+  def isSameMethod_referenceAndDeclaration {
+    project.create("ReferenceAndDeclaration.scala") {"""
+      class ReferenceAndDeclaration {
+        def fo|o(x: String) = x
+        def bar(x: String) = fo|o(x)
+      }
+    """} isSameMethod(true)
+  }
+
+  @Test
+  def isSameMethod_referenceAndDeclarationWithError{
+    project.create("WithError.scala") {"""
+      class ReferenceAndDeclaration {
+        def fo|o(x: String) = x
+        def bar(x: String) = invalid(fo|o(x))
+      }
+    """} isSameMethod(false)
+  }
+
+  @Test
+  def isSameMethod_referenceAndDeclarationInSeperateClass {
+    project.create("ReferenceAndDeclarationInSeperateClass.scala") {"""
+      class A {
+        def fo|o(x: String) = x
+      }
+      class B {
+        def bar(x: String) = (new A).fo|o(x)
+      }
+    """} isSameMethod(true)
+  }
+
+  @Test
+  def isSameMethod_falseForDifferentMethods {
+    project.create("FalseForDifferentMethods.scala") {"""
+      class FalseForDifferentMethods {
+        def ad|dStrings(x: String, y: String) = x + y
+        def ad|dInts(x: Int, y: Int) = x + y
+      }
+    """} isSameMethod(false)
+  }
+
+  @Test
+  def isSameMethod_overriddenCountsAsSame {
+    project.create("OverriddenCountsAsSame.scala") {"""
+      class A {
+        def fo|o(x: String) = x
+      }
+      class B extends A {
+        override def fo|o(x: String) = x
+      }
+    """} isSameMethod(true)
+  }
+
+  @Test
+  def isSameMethod_overriddenValCountsAsSame {
+    project.create("OverriddenCountsAsSame.scala") {"""
+      class A {
+        def fo|o: String = "hi"
+      }
+      class B extends A {
+        override val fo|o: String = "there"
+      }
+    """} isSameMethod(true)
+  }
+
+  @Test
+  def isSameMethod_typeAliases {
+    project.create("TypeAliases.scala") {"""
+      class A {
+        def fo|o: String = "hi"
+      }
+      class B extends A {
+        type S = String
+        override def fo|o: S = "there"
+      }
+    """} isSameMethod(true)
+  }
+
+  @Test
+  def isSameMethod_canDistinguishOverloadedMethods {
+    project.create("CanDistinguishOverloadedMethods.scala") {"""
+      class A {
+        def ad|d(x: String, y: String) = x + y
+        def ad|d(x: Int, y: Int) = x + y
+      }
+    """} isSameMethod(false)
+  }
+
+  @Test
+  def isSameMethod_partiallyAppliedMethod {
+    project.create("PartiallyApplied.scala") {"""
+      trait A {
+        def fo|o(x: String): String
+        def bar: String => String = fo|o
+      }
+    """} isSameMethod(true)
+  }
+
+  @Test
+  def isSameMethod_canHandleSubclasses {
+    // It needs to be able to
+    project.create("CanHandleSubclasses.scala") {"""
+      class A {
+        def fo|o(x: String): String = x
+      }
+      class B extends A {
+        def bar = fo|o("test")
+      }
+    """} isSameMethod(true)
+  }
+
+  @Test
+  def isSameMethod_canHandleTraits {
+    project.create("CanHandleTraits.scala") {"""
+      trait A {
+        def fo|o(x: String): String = x
+      }
+      class B extends A {
+        def bar = fo|o("test")
+      }
+    """} isSameMethod(true)
+  }
+
+  @Test
+  def isSameMethod_abstractOverrideDeclaration {
+    project.create("AbstractOverrideDeclaration.scala") {"""
+      trait A {
+        def fo|o(x: String): String
+      }
+      class B extends A {
+        abstract override def fo|o(x: String): String = "Test"
+      }
+    """} isSameMethod(true)
+  }
+
+  @Test
+  def isSameMethod_abstractOverrideSuperReference {
+    project.create("AbstractOverrideDeclaration.scala") {"""
+      trait A {
+        def fo|o(x: String): String
+      }
+      trait B extends A {
+        abstract override def foo(x: String): String = {
+          super.f|oo(x)+"Test"
+        }
+      }
+    """} isSameMethod(true)
+  }
+
+  @Test
+  def isSameMethod_thisTypes {
+    project.create("ThisTypes.scala") {"""
+      class A {
+        def m|e: this.type = this
+      }
+      class B extends A {
+        override def m|e: this.type = this
+      }
+    """} isSameMethod(true)
+  }
+
+  @Test
+  def isSameMethod_casting {
+    project.create("Casting.scala") {"""
+      class A {
+        def fo|o(x: String): String = x
+        def bar = (new Object).asInstanceOf[A].fo|o("test")
+      }
+    """} isSameMethod(true)
+  }
+
+  @Test def isSameMethod_constructorsAreMethodsToo {
+    project.create("Constructors.scala") {"""
+      class A {
+        def th|is(x: String) {
+          this()
+        }
+      }
+      class B {
+        def foo = ne|w A("test")
+      }
+    """} isSameMethod(true)
+  }
+
+  @Test
+  def isSameMethod_constructorInvocation {
+    project.create("ConstructorReference.scala") {"""
+      class A {
+        def t|his(x: String) {
+          this()
+        }
+        def this(x: String, y: String){
+          t|his(x)
+        }
+      }
+    """} isSameMethod(true)
+  }
+
+  @Test def isSameMethod_selfTypes {
+    project.create("Constructors.scala") {"""
+      trait A {
+        def fo|o(x: String): String = x
+      }
+      class B { this: A =>
+        def bar = fo|o("test")
+      }
+    """} isSameMethod(true)
+  }
+
+  @Test
+  def isSameMethod_canHandleRenamedMethods {
+    project.create("CanHandleRenamedMethods.scala") {"""
+      class C {
+        import C.{ foo => bar }
+        val y = b|ar("hi")
+      }
+      object C {
+        def fo|o(x: String) = x
+      }
+    """} isSameMethod(true)
+  }
+
+  @Test
+  def isSameMethod_worksWithSameProject {
+
+    val p1 = Project("SearchPresentationCompilerTest-worksWithSameProject")
+
+    val latch = new CountDownLatch(2)
+    val observer = FileChangeObserver(p1.scalaProject)(onAdded = _ => latch.countDown)
+
+    val sourceA = p1.create("A.scala")("""
+      class A {
+        def f|oo(x: String) = x.reverse
+      }""")
+
+    val sourceB = p1.create("B.scala")("""
+      class B {
+        def bar(x: String) = (new A()).fo|o("test")
+      }""")
+
+    latch.await(5,java.util.concurrent.TimeUnit.SECONDS)
+
+    sourceA.isSameMethodAs(sourceB)
+
+    p1.delete
+    observer.stop
+  }
+
+  @Test
+  def isSameMethod_workWithDifferentProjects {
+    /*
+     * Test that we can compare symbols from two different projects.
+     *
+     * In this case project p2 depends on p1 and uses a class A defined in p1. We
+     * want to make sure that it can compare the references to members of A in
+     * project p2 with A in p1
+     */
+
+    val p1 = Project("SearchPresentationCompilerTest-workWithDifferentProjects-1")
+    val p2 = Project("SearchPresentationCompilerTest-workWithDifferentProjects-2")
+
+    val latch = new CountDownLatch(2)
+
+    val observer1 = FileChangeObserver(p1.scalaProject)(onAdded = _ => latch.countDown)
+    val observer2 = FileChangeObserver(p2.scalaProject)(onAdded = _ => latch.countDown)
+
+    p2.addProjectsToClasspath(p1)
+
+    val sourceA = p1.create("A.scala")("""
+      class A {
+        def f|oo(x: String) = x.reverse
+      }""")
+
+    val sourceB = p2.create("B.scala")("""
+      class B {
+        def bar(x: String) = (new A()).fo|o("test")
+      }""")
+
+    latch.await(5,java.util.concurrent.TimeUnit.SECONDS)
+
+    sourceA.isSameMethodAs(sourceB)
+
+    p1.delete
+    p2.delete
+    observer1.stop
+    observer2.stop
+  }
+
+  @Test
+  def isSameMethod_worksWithDifferentProjectsNotOnCP {
+    /*
+     * In this case we have
+     *
+     *     (P1)
+     *     /  \
+     *    /    \
+     *  (P2)  (P3)
+     *
+     * Now, we want to make sure that using the PC of P3 we can compare symbols between
+     * P3 and P2 given that they're defined in P1.
+     */
+    val p1 = Project("SearchPresentationCompilerTest-worksWithDifferentProjectsNotOnCP-1")
+    val p2 = Project("SearchPresentationCompilerTest-worksWithDifferentProjectsNotOnCP-2")
+    val p3 = Project("SearchPresentationCompilerTest-worksWithDifferentProjectsNotOnCP-3")
+
+    p2.addProjectsToClasspath(p1)
+    p3.addProjectsToClasspath(p1)
+
+    val latch = new CountDownLatch(3)
+
+    val observer1 = FileChangeObserver(p1.scalaProject)(onAdded = _ => latch.countDown)
+    val observer2 = FileChangeObserver(p2.scalaProject)(onAdded = _ => latch.countDown)
+    val observer3 = FileChangeObserver(p3.scalaProject)(onAdded = _ => latch.countDown)
+
+    val sourceA = p1.create("A.scala")("""
+      class A {
+        def f|oo(x: String) = x.reverse
+      }""")
+
+    val sourceB = p2.create("B.scala")("""
+      class B {
+        def bar(x: String) = (new A()).fo|o("test")
+      }""")
+
+    val sourceC = p3.create("C.scala")("""
+      class C {
+        def bar(x: String) = (new A()).fo|o("test")
+      }""")
+
+    latch.await(5,java.util.concurrent.TimeUnit.SECONDS)
+
+    sourceB.isSameMethodAs(sourceA)
+    sourceC.isSameMethodAs(sourceA)
+    sourceC.isSameMethodAs(sourceB)
+
+    p1.delete
+    p2.delete
+    p3.delete
+    observer1.stop
+    observer2.stop
+    observer3.stop
   }
 }
 
 object SearchPresentationCompilerTest
-  extends TestProjectSetup("SearchPresentationCompilerTest", bundleName= "org.scala.tools.eclipse.search.tests")
-     with TestUtil
-
+     extends TestUtil
+        with SourceCreator

--- a/org.scala.tools.eclipse.search/src/org/scala/tools/eclipse/search/searching/SearchPresentationCompiler.scala
+++ b/org.scala.tools.eclipse.search/src/org/scala/tools/eclipse/search/searching/SearchPresentationCompiler.scala
@@ -15,13 +15,19 @@ object SearchPresentationCompiler extends HasLogger {
    */
   implicit class SearchPresentationCompiler(val pc: ScalaPresentationCompiler) {
 
+    // ADT used to express the result of symbolAt.
+    sealed abstract class SymbolRequest
+    case class FoundSymbol(symbol: pc.Symbol) extends SymbolRequest
+    case object MissingSymbol extends SymbolRequest
+    case object NotTypeable extends SymbolRequest
+
     /**
      * Get the symbol of the entity at a given location in a file.
      *
      * The source file needs to be loaded before invoking this method. This can be
      * achieved by invoking `pc.askReload(..)`.
      */
-    def symbolAt[A](loc: Location, cu: SourceFile): Option[pc.Symbol] = {
+    def symbolAt[A](loc: Location, cu: SourceFile): SymbolRequest = {
       val typed = new Response[pc.Tree]
       val pos = new OffsetPosition(cu, loc.offset)
       pc.askTypeAt(pos, typed)
@@ -29,16 +35,71 @@ object SearchPresentationCompiler extends HasLogger {
         tree => filterNoSymbols(tree.symbol),
         err => {
           logger.debug(err)
-          None
+          NotTypeable
         })
     }
 
-    private def filterNoSymbols(sym: pc.Symbol): Option[pc.Symbol] = {
-      if (sym == null || sym == pc.NoSymbol) {
-        None
+    private def filterNoSymbols(sym: pc.Symbol): SymbolRequest = {
+      if (sym == null) {
+        MissingSymbol // Symbol is null if there isn't any node at the given location (I think!)
+      } else if (sym == pc.NoSymbol) {
+        NotTypeable // NoSymbol if we can't typecheck the given node.
       } else {
-        Some(sym)
+        FoundSymbol(sym)
       }
+    }
+
+    /**
+     * Import a symbol from one presentation compiler into another. This is required
+     * before you can compare two symbols originating from different presentation
+     * compiler instance.
+     *
+     * TODO: Is the imported symbol discarded again, or does this create a memory leak?
+     *       Ticket #1001703
+     */
+    def importSymbol(spc: SearchPresentationCompiler)(s: spc.pc.Symbol): pc.Symbol = {
+      // https://github.com/scala/scala/blob/master/src/reflect/scala/reflect/api/Importers.scala
+      val importer0 = pc.mkImporter(spc.pc)
+      val importer = importer0.asInstanceOf[pc.Importer { val from: spc.pc.type }]
+      importer.importSymbol(s)
+    }
+
+    /**
+     * Check if symbols `s1` and `s2` are describing the same method. We consider two
+     * methods to be the same if
+     *
+     *  - They have the same name
+     *  - s1.owner and s2.owner are in the same hierarchy
+     *  - They have the same type signature or one is overriding the other
+     */
+    def isSameMethod(s1: pc.Symbol, s2: pc.Symbol): Boolean = {
+      pc.askOption { () =>
+
+        lazy val isInHiearchy = s1.owner.isSubClass(s2.owner) || s2.owner.isSubClass(s1.owner)
+
+        lazy val hasSameName = {
+          def getName(s: pc.Symbol)= {
+            if(pc.nme.isLocalName(s.name))
+              pc.nme.localToGetter(s.name.toTermName)
+            else s.name
+          }
+          getName(s1) == getName(s2)
+        }
+
+        lazy val hasSameTypeSignature = s1.typeSignature =:= s2.typeSignature
+
+        // If s1 and s2 are defined in the same class the owner will be the same
+        // thus s1.overriddenSymbol(S2.owner) will actually return s1.
+        lazy val isOverridden = s1.owner != s2.owner &&
+                                (s1.overriddenSymbol(s2.owner) != pc.NoSymbol ||
+                                s2.overriddenSymbol(s1.owner) != pc.NoSymbol)
+
+        (s1 == s2) || // Fast-path.
+        hasSameName &&
+        isInHiearchy &&
+        (hasSameTypeSignature || isOverridden)
+
+      } getOrElse false
     }
 
   }


### PR DESCRIPTION
The SearchPresentationCompiler can now compare two symbols and
check if they describe the same method.

This works even for symbols that have been obtained from seperate
presentation compilers; we use Importers to take care of that.

fixes #1001683
