### PR TITLE
Provides API for finding exact occurrences of enity at location

### DIFF
--- a/org.scala.tools.eclipse.search.tests/src/org/scala/tools/eclipse/search/LogErrorReporter.scala
+++ b/org.scala.tools.eclipse.search.tests/src/org/scala/tools/eclipse/search/LogErrorReporter.scala
@@ -1,0 +1,9 @@
+package org.scala.tools.eclipse.search
+
+import scala.tools.eclipse.logging.HasLogger
+
+trait LogErrorReporter extends ErrorReporter with HasLogger {
+
+  def reportError(msg: String): Unit = logger.debug(msg)
+
+}

--- a/org.scala.tools.eclipse.search.tests/src/org/scala/tools/eclipse/search/TestsSuite.scala
+++ b/org.scala.tools.eclipse.search.tests/src/org/scala/tools/eclipse/search/TestsSuite.scala
@@ -19,5 +19,6 @@ import org.scala.tools.eclipse.search.searching._
   ,classOf[ProjectChangeObserverTest]
   ,classOf[SearchPresentationCompilerTest]
   ,classOf[ProjectFinderTest]
+  ,classOf[FinderTest]
 ))
 class TestsSuite {}

--- a/org.scala.tools.eclipse.search.tests/src/org/scala/tools/eclipse/search/searching/FinderTest.scala
+++ b/org.scala.tools.eclipse.search.tests/src/org/scala/tools/eclipse/search/searching/FinderTest.scala
@@ -1,0 +1,224 @@
+package org.scala.tools.eclipse.search.searching
+
+import scala.tools.eclipse.testsetup.SDTTestUtils
+import org.scala.tools.eclipse.search.indexing.Index
+import org.scala.tools.eclipse.search.indexing.SourceIndexer
+import org.eclipse.core.runtime.Path
+import org.scala.tools.eclipse.search.TestUtil
+import org.junit.Test
+import org.junit.Assert._
+import scala.tools.eclipse.javaelements.ScalaCompilationUnit
+import scala.tools.eclipse.EclipseUserSimulator
+import org.eclipse.core.runtime.NullProgressMonitor
+import org.scala.tools.eclipse.search.searching.SourceCreator
+import java.util.concurrent.CountDownLatch
+import org.scala.tools.eclipse.search.FileChangeObserver
+import org.scala.tools.eclipse.search.LogErrorReporter
+import scala.tools.eclipse.ScalaProject
+import org.apache.lucene.search.IndexSearcher
+import scala.util.Try
+import scala.util.Failure
+import java.io.IOException
+
+class FinderTest {
+
+  /*
+   * This won't have very many tests. The most interesting parts are in the components
+   * that are used by the Finder, and they have separate tests. E.g. see
+   * SearchPresentationCompiler for how symbols are compared.
+   */
+
+  import FinderTest._
+
+  @Test
+  def canFindOccurrencesInSameProject = {
+
+    val config = new Index with SourceIndexer with Finder with LogErrorReporter {
+      override val base = INDEX_DIR
+    }
+
+    val project = Project("FinderTest")
+
+    val latch = new CountDownLatch(2)
+    val observer = FileChangeObserver(project.scalaProject)(onAdded = _ => latch.countDown)
+
+    val sourceA = project.create("A.scala")("""
+      class A {
+        def f|oo(x: String) = x.reverse
+      }
+    """)
+
+    val sourceB = project.create("B.scala")("""
+      class B {
+        def bar = (new A).f|oo("test")
+      }
+    """)
+
+    latch.await(5, java.util.concurrent.TimeUnit.SECONDS)
+
+    config.indexProject(project.scalaProject)
+
+    @volatile var results = 0
+    config.occurrencesOfEntityAt(Location(sourceA.unit, sourceA.markers.head)) { loc =>
+      results += 1
+    }
+
+    assertEquals(s"Checking references of method foo, Found ${results}", 2, results)
+
+    project.delete
+    observer.stop
+  }
+
+  @Test
+  def canFindOccurrencesInDifferentProjects = {
+
+    val config = new Index with SourceIndexer with Finder with LogErrorReporter {
+      override val base = INDEX_DIR
+    }
+
+    val project1 = Project("FinderTest-DifferentProjects1")
+    val project2 = Project("FinderTest-DifferentProjects2")
+
+    project2.addProjectsToClasspath(project1)
+
+    val latch = new CountDownLatch(2)
+    val observer1 = FileChangeObserver(project1.scalaProject)(onAdded = _ => latch.countDown)
+    val observer2 = FileChangeObserver(project2.scalaProject)(onAdded = _ => latch.countDown)
+
+    val sourceA = project1.create("A.scala")("""
+      class A {
+        def f|oo(x: String) = x.reverse
+      }
+    """)
+
+    val sourceB = project2.create("B.scala")("""
+      class B {
+        def bar = (new A).f|oo("test")
+      }
+    """)
+
+    latch.await(5, java.util.concurrent.TimeUnit.SECONDS)
+
+    config.indexProject(project1.scalaProject)
+    config.indexProject(project2.scalaProject)
+
+    @volatile var results = 0
+    config.occurrencesOfEntityAt(Location(sourceA.unit, sourceA.markers.head)) { loc =>
+      results += 1
+    }
+
+    assertEquals(s"Checking references of method foo, Found ${results}", 2, results)
+
+    project1.delete
+    project2.delete
+    observer1.stop
+    observer2.stop
+  }
+
+  @Test
+  def reportsSearchFailures = {
+    /*
+     * Should the Index break in some way that can't be handled lower
+     * in the hierarchy, we want to know about it.
+     */
+
+    val project1 = Project("FinderTest-IndexFailure1")
+    val project2 = Project("FinderTest-IndexFailure2")
+
+    val config = new Index with SourceIndexer with Finder with LogErrorReporter {
+      override val base = INDEX_DIR
+      // Emulate a failure for the index of project2.
+      override protected def withSearcher[A](project: ScalaProject)(f: IndexSearcher => A): Try[A] = {
+        if (project == project2.scalaProject) {
+          Failure(new IOException)
+        } else super.withSearcher(project)(f)
+      }
+    }
+
+    project2.addProjectsToClasspath(project1)
+
+    val latch = new CountDownLatch(2)
+    val observer1 = FileChangeObserver(project1.scalaProject)(onAdded = _ => latch.countDown)
+    val observer2 = FileChangeObserver(project2.scalaProject)(onAdded = _ => latch.countDown)
+
+    val sourceA = project1.create("A.scala")("""
+      class A {
+        def f|oo(x: String) = x.reverse
+      }
+    """)
+
+    val sourceB = project2.create("B.scala")("""
+      class B {
+        def bar = (new A).f|oo("test")
+      }
+    """)
+
+    latch.await(5, java.util.concurrent.TimeUnit.SECONDS)
+
+    config.indexProject(project1.scalaProject)
+    config.indexProject(project2.scalaProject)
+
+    @volatile var hits = 0
+    @volatile var failures = 0
+    config.occurrencesOfEntityAt(Location(sourceA.unit, sourceA.markers.head))(
+      hit = _ => hits += 1,
+      errorHandler = _ => failures += 1)
+
+    assertEquals(s"Expected the search to find 1 hit, but found ${hits}", 1, hits)
+    assertEquals(s"Expected the search to have 1 error, but got ${failures}", 1, failures)
+
+    project1.delete
+    project2.delete
+    observer1.stop
+    observer2.stop
+  }
+
+  @Test
+  def reportsUntypeableOccurrences = {
+
+    /*
+     * When a occurrence is found in the index and we can't type-check
+     * the given point we want to be able to report that occurrence as
+     * a potential hit.
+     */
+    val config = new Index with SourceIndexer with Finder with LogErrorReporter {
+      override val base = INDEX_DIR
+    }
+
+    val project = Project("FinderTest-UntableableOccurrence")
+
+    val latch = new CountDownLatch(2)
+    val observer = FileChangeObserver(project.scalaProject)(onAdded = _ => latch.countDown)
+
+    val sourceA = project.create("A.scala")("""
+      class A {
+        def fo|o(x: String) = x
+        def bar(x: String) = invalid(foo(x))
+      }
+    """)
+
+    latch.await(5, java.util.concurrent.TimeUnit.SECONDS)
+
+    config.indexProject(project.scalaProject)
+
+    @volatile var hits = 0
+    @volatile var potentialHits = 0
+    config.occurrencesOfEntityAt(Location(sourceA.unit, sourceA.markers.head))(
+      hit = loc => hits += 1,
+      potentialHit = loc => potentialHits += 1)
+
+    assertEquals(s"Expected the search to find 1 hit, but found ${hits}", 1, hits)
+    assertEquals(s"Expected the search to find 1 potential hit, but found ${potentialHits}", 1, potentialHits)
+
+    project.delete
+    observer.stop
+  }
+
+}
+
+object FinderTest extends TestUtil
+    with SourceCreator {
+
+  val INDEX_DIR = new Path(mkPath("target", "FinderTestIndex"))
+
+}

--- a/org.scala.tools.eclipse.search.tests/src/org/scala/tools/eclipse/search/searching/SearchPresentationCompilerTest.scala
+++ b/org.scala.tools.eclipse.search.tests/src/org/scala/tools/eclipse/search/searching/SearchPresentationCompilerTest.scala
@@ -5,7 +5,6 @@ import org.junit.After
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
-import org.scala.tools.eclipse.search.SourceCreator
 import org.scala.tools.eclipse.search.TestUtil
 import SearchPresentationCompilerTest.Project
 import org.scala.tools.eclipse.search.FileChangeObserver
@@ -16,7 +15,6 @@ import org.junit.Ignore
 class SearchPresentationCompilerTest {
 
   import SearchPresentationCompilerTest._
-  import SearchPresentationCompiler._
 
   private val project = Project("SearchPresentationCompilerTest")
 
@@ -77,6 +75,21 @@ class SearchPresentationCompilerTest {
       class ExampleWithSymbol3 {
         def foo(x: String) = x
         def bar(x: String) = invalid(fo|o(x))
+      }
+    """} expectedTypeError
+  }
+
+  @Test
+  def notTypeableIfAskedForLocationWithTypeErrorClasses {
+    project.create("NotTypeableClassA.scala") {"""
+      class A {
+        def fo|o(x: String) = x
+      }
+    """}
+
+    project.create("NotTypeableClassB.scala") {"""
+      class B {
+        def bar = invalid((new A).fo|o("test"))
       }
     """} expectedTypeError
   }
@@ -152,6 +165,18 @@ class SearchPresentationCompilerTest {
       }
       class B extends A {
         override val fo|o: String = "there"
+      }
+    """} isSameMethod(true)
+  }
+
+  @Test
+  def isSameMethod_overriddenVarCountAsSame {
+    project.create("OverriddenVarCountsAsSame.scala") {"""
+      trait A {
+        def fo|o_=(x: String): Unit
+      }
+      abstract class B extends A {
+        var f|oo: String
       }
     """} isSameMethod(true)
   }

--- a/org.scala.tools.eclipse.search.tests/src/org/scala/tools/eclipse/search/searching/TestSearchPresentationCompiler.scala
+++ b/org.scala.tools.eclipse.search.tests/src/org/scala/tools/eclipse/search/searching/TestSearchPresentationCompiler.scala
@@ -1,0 +1,28 @@
+package org.scala.tools.eclipse.search.searching
+
+import scala.tools.eclipse.ScalaPresentationCompiler
+
+/**
+ * Some extra methods that are convenient for the test code.
+ */
+class TestSearchPresentationCompiler(pc: ScalaPresentationCompiler) extends SearchPresentationCompiler(pc) {
+
+  def isNoSymbol(loc: Location): Boolean = {
+    loc.cu.withSourceFile{ (sf, pc) =>
+      symbolAt(loc, sf) match {
+        case MissingSymbol => true
+        case x => false
+      }
+    }(false)
+  }
+
+  def isTypeError(loc: Location): Boolean = {
+    loc.cu.withSourceFile{ (sf, pc) =>
+      symbolAt(loc, sf) match {
+        case NotTypeable => true
+        case x => false
+      }
+    }(false)
+  }
+
+}

--- a/org.scala.tools.eclipse.search/src/org/scala/tools/eclipse/search/ErrorReporter.scala
+++ b/org.scala.tools.eclipse.search/src/org/scala/tools/eclipse/search/ErrorReporter.scala
@@ -1,0 +1,11 @@
+package org.scala.tools.eclipse.search
+
+
+/**
+ * Convenience trait for reporting errors to the user.
+ */
+trait ErrorReporter {
+
+  def reportError(msg: String): Unit
+
+}

--- a/org.scala.tools.eclipse.search/src/org/scala/tools/eclipse/search/package.scala
+++ b/org.scala.tools.eclipse.search/src/org/scala/tools/eclipse/search/package.scala
@@ -1,0 +1,16 @@
+package org.scala.tools.eclipse
+
+package object search {
+  /**
+   * Implicit value class that makes it easier to log or report errors
+   * inside for-comprehensions.
+   */
+  implicit class ErrorHandlingOption[A](val op: Option[A]) extends AnyVal {
+    def onEmpty(f: => Unit): Option[A] = {
+      if (op.isEmpty) {
+        f
+        None
+      } else op
+    }
+  }
+}

--- a/org.scala.tools.eclipse.search/src/org/scala/tools/eclipse/search/searching/Finder.scala
+++ b/org.scala.tools.eclipse.search/src/org/scala/tools/eclipse/search/searching/Finder.scala
@@ -1,0 +1,59 @@
+package org.scala.tools.eclipse.search
+package searching
+
+import org.scala.tools.eclipse.search.indexing.Index
+import scala.tools.eclipse.ScalaPlugin
+import org.scala.tools.eclipse.search.ErrorReporter
+import scala.tools.eclipse.logging.HasLogger
+
+/**
+ * Component that provides various methods related to finding Scala entities.
+ */
+trait Finder extends ProjectFinder
+                with ErrorReporter
+                with HasLogger {
+
+  this: Index =>
+
+  /**
+   * Find all occurrences of the entity at the given location.
+   *
+   * - Exact matches are passed to the `hit` function.
+   * - Potential matches are passed to the `potentialHit` function. A potential
+   *   match is when the index reports and occurrence but we can't type-check
+   *   the given point to see if it is an exact match.
+   * - Should any errors occur in the Index that we can't handle, the failures
+   *   are passed to the `errorHandler` function.
+   */
+  def occurrencesOfEntityAt(location: Location)(hit: Location => Unit,
+                                                potentialHit: Location => Unit = _ => (),
+                                                errorHandler: SearchFailure => Unit = _ => ()): Unit = {
+
+    // Find all the Scala projects that are relevant to search in.
+    val enclosingProject = location.cu.scalaProject.underlying
+    val all =  projectClosure(enclosingProject)
+    val allScala = all.map(ScalaPlugin.plugin.asScalaProject(_)).flatten
+
+    // Get the symbol under the cursor. Use it to find other occurrences.
+    location.cu.withSourceFile { (sf, pc) =>
+      val spc = new SearchPresentationCompiler(pc)
+      for {
+        comparator <- spc.comparator(location) onEmpty reportError(s"Couldn't get comparator based on symbol at ${location.offset} in ${sf.file.path}")
+        name <- spc.nameOfEntityAt(location) onEmpty reportError(s"Couldn't get name of symbol at ${location.offset} in ${sf.file.path}")
+      } {
+        val (occurrences, failures) = findOccurrences(name, allScala)
+        failures.foreach(errorHandler)
+        occurrences.foreach { occurrence =>
+          occurrence.file.withSourceFile { (sf, _) =>
+            val loc = Location(occurrence.file, occurrence.offset)
+            comparator.isSameAs(loc) match {
+              case Same => hit(loc)
+              case PossiblySame => potentialHit(loc)
+              case NotSame => 
+            }
+          }(reportError(s"Could not access source file ${occurrence.file.getPath.toOSString}"))
+        }
+      }
+    }(reportError(s"Could not access source file ${location.cu.file.path}"))
+  }
+}

--- a/org.scala.tools.eclipse.search/src/org/scala/tools/eclipse/search/searching/SearchPresentationCompiler.scala
+++ b/org.scala.tools.eclipse.search/src/org/scala/tools/eclipse/search/searching/SearchPresentationCompiler.scala
@@ -5,102 +5,153 @@ import scala.reflect.internal.util.SourceFile
 import scala.tools.nsc.interactive.Response
 import scala.reflect.internal.util.OffsetPosition
 import scala.tools.eclipse.logging.HasLogger
+import org.scala.tools.eclipse.search.indexing.Occurrence
 
-object SearchPresentationCompiler extends HasLogger {
+sealed abstract class ComparisionResult
+case object Same extends ComparisionResult
+case object NotSame extends ComparisionResult
+case object PossiblySame extends ComparisionResult
+
+trait SymbolComparator {
+  def isSameAs(loc: Location): ComparisionResult
+}
+
+/**
+ * Encapsulates PC logic. Makes it easier to control where the compiler data
+ * structures are used and thus make sure that we conform to the synchronization
+ * policy of the presentation compiler.
+ */
+class SearchPresentationCompiler(val pc: ScalaPresentationCompiler) extends HasLogger {
+
+  // ADT used to express the result of symbolAt.
+  protected sealed abstract class SymbolRequest
+  protected case class FoundSymbol(symbol: pc.Symbol) extends SymbolRequest
+  protected case object MissingSymbol extends SymbolRequest
+  protected case object NotTypeable extends SymbolRequest
 
   /**
-   * Encapsulates PC logic. Makes it easier to control where the compiler data
-   * structures are used and thus make sure that we conform to the synchronization
-   * policy of the presentation compiler.
+   * Find the name of the symbol at the given location. Returns
+   * None if it can't find a valid symbol at the given location.
    */
-  implicit class SearchPresentationCompiler(val pc: ScalaPresentationCompiler) {
-
-    // ADT used to express the result of symbolAt.
-    sealed abstract class SymbolRequest
-    case class FoundSymbol(symbol: pc.Symbol) extends SymbolRequest
-    case object MissingSymbol extends SymbolRequest
-    case object NotTypeable extends SymbolRequest
-
-    /**
-     * Get the symbol of the entity at a given location in a file.
-     *
-     * The source file needs to be loaded before invoking this method. This can be
-     * achieved by invoking `pc.askReload(..)`.
-     */
-    def symbolAt[A](loc: Location, cu: SourceFile): SymbolRequest = {
-      val typed = new Response[pc.Tree]
-      val pos = new OffsetPosition(cu, loc.offset)
-      pc.askTypeAt(pos, typed)
-      typed.get.fold(
-        tree => filterNoSymbols(tree.symbol),
-        err => {
-          logger.debug(err)
-          NotTypeable
-        })
-    }
-
-    private def filterNoSymbols(sym: pc.Symbol): SymbolRequest = {
-      if (sym == null) {
-        MissingSymbol // Symbol is null if there isn't any node at the given location (I think!)
-      } else if (sym == pc.NoSymbol) {
-        NotTypeable // NoSymbol if we can't typecheck the given node.
-      } else {
-        FoundSymbol(sym)
+  def nameOfEntityAt(loc: Location): Option[String] = {
+    loc.cu.withSourceFile({ (sf, pc) =>
+      symbolAt(loc, sf) match {
+        case FoundSymbol(symbol) =>
+          pc.askOption(() => symbol.nameString)
+        case _ => None
       }
-    }
+    })(None)
+  }
 
-    /**
-     * Import a symbol from one presentation compiler into another. This is required
-     * before you can compare two symbols originating from different presentation
-     * compiler instance.
-     *
-     * TODO: Is the imported symbol discarded again, or does this create a memory leak?
-     *       Ticket #1001703
-     */
-    def importSymbol(spc: SearchPresentationCompiler)(s: spc.pc.Symbol): pc.Symbol = {
-      // https://github.com/scala/scala/blob/master/src/reflect/scala/reflect/api/Importers.scala
-      val importer0 = pc.mkImporter(spc.pc)
-      val importer = importer0.asInstanceOf[pc.Importer { val from: spc.pc.type }]
-      importer.importSymbol(s)
-    }
-
-    /**
-     * Check if symbols `s1` and `s2` are describing the same method. We consider two
-     * methods to be the same if
-     *
-     *  - They have the same name
-     *  - s1.owner and s2.owner are in the same hierarchy
-     *  - They have the same type signature or one is overriding the other
-     */
-    def isSameMethod(s1: pc.Symbol, s2: pc.Symbol): Boolean = {
-      pc.askOption { () =>
-
-        lazy val isInHiearchy = s1.owner.isSubClass(s2.owner) || s2.owner.isSubClass(s1.owner)
-
-        lazy val hasSameName = {
-          def getName(s: pc.Symbol)= {
-            if(pc.nme.isLocalName(s.name))
-              pc.nme.localToGetter(s.name.toTermName)
-            else s.name
+  /**
+   * Get a comparator for a symbol at a given Location. The Comparator can be
+   * used to see if symbols at other locations are the same as this symbol.
+   */
+  def comparator(loc: Location): Option[SymbolComparator] = {
+    loc.cu.withSourceFile({ (sf, pc) =>
+      symbolAt(loc, sf) match {
+        case FoundSymbol(symbol) => Some(new SymbolComparator {
+          def isSameAs(otherLoc: Location): ComparisionResult = {
+            otherLoc.cu.withSourceFile({ (otherSf, otherPc) =>
+              val otherSpc = new SearchPresentationCompiler(otherPc)
+              otherSpc.symbolAt(otherLoc, otherSf) match {
+                case otherSpc.FoundSymbol(symbol2) =>
+                  pc.askOption(() => {
+                    val imported = importSymbol(otherSpc)(symbol2)
+                    if(isSameMethod(symbol, imported)) Same else NotSame
+                  }) getOrElse NotSame
+                case _ => PossiblySame
+              }
+            })(PossiblySame)
           }
-          getName(s1) == getName(s2)
-        }
+        })
+        case _ => None
+      }
+    })(None)
+  }
 
-        lazy val hasSameTypeSignature = s1.typeSignature =:= s2.typeSignature
+  /**
+   * Get the symbol of the entity at a given location in a file.
+   *
+   * The source file needs to be loaded before invoking this method. This can be
+   * achieved by invoking `pc.askReload(..)`.
+   */
+  protected def symbolAt[A](loc: Location, cu: SourceFile): SymbolRequest = {
+    val typed = new Response[pc.Tree]
+    val pos = new OffsetPosition(cu, loc.offset)
+    pc.askTypeAt(pos, typed)
+    typed.get.fold(
+      tree => filterNoSymbols(tree.symbol),
+      err => {
+        logger.debug(err)
+        NotTypeable
+      })
+  }
 
-        // If s1 and s2 are defined in the same class the owner will be the same
-        // thus s1.overriddenSymbol(S2.owner) will actually return s1.
-        lazy val isOverridden = s1.owner != s2.owner &&
-                                (s1.overriddenSymbol(s2.owner) != pc.NoSymbol ||
-                                s2.overriddenSymbol(s1.owner) != pc.NoSymbol)
-
-        (s1 == s2) || // Fast-path.
-        hasSameName &&
-        isInHiearchy &&
-        (hasSameTypeSignature || isOverridden)
-
-      } getOrElse false
+  private def filterNoSymbols(sym: pc.Symbol): SymbolRequest = {
+    if (sym == null) {
+      MissingSymbol // Symbol is null if there isn't any node at the given location (I think!)
+    } else if (sym == pc.NoSymbol) {
+      NotTypeable // NoSymbol if we can't typecheck the given node.
+    } else {
+      FoundSymbol(sym)
     }
+  }
 
+  /**
+   * Import a symbol from one presentation compiler into another. This is required
+   * before you can compare two symbols originating from different presentation
+   * compiler instance.
+   *
+   * @note it should always be called within the Presentation Compiler Thread.
+   *
+   * TODO: Is the imported symbol discarded again, or does this create a memory leak?
+   *       Ticket #1001703
+   */
+  private def importSymbol(spc: SearchPresentationCompiler)(s: spc.pc.Symbol): pc.Symbol = {
+    // https://github.com/scala/scala/blob/master/src/reflect/scala/reflect/api/Importers.scala
+    val importer0 = pc.mkImporter(spc.pc)
+    val importer = importer0.asInstanceOf[pc.Importer { val from: spc.pc.type }]
+    importer.importSymbol(s)
+  }
+
+  /**
+   * Check if symbols `s1` and `s2` are describing the same method. We consider two
+   * methods to be the same if
+   *
+   *  - They have the same name
+   *  - s1.owner and s2.owner are in the same hierarchy
+   *  - They have the same type signature or one is overriding the other
+   */
+  private def isSameMethod(s1: pc.Symbol, s2: pc.Symbol): Boolean = {
+    pc.askOption { () =>
+
+      lazy val isInHiearchy = s1.owner.isSubClass(s2.owner) || s2.owner.isSubClass(s1.owner)
+
+      lazy val hasSameName = {
+        def getName(s: pc.Symbol)= {
+          if (pc.nme.isSetterName(s.name))
+            pc.nme.setterToGetter(s.name.toTermName)
+          else if(pc.nme.isLocalName(s.name))
+            pc.nme.localToGetter(s.name.toTermName)
+          else s.name
+        }
+        getName(s1) == getName(s2)
+      }
+
+      lazy val hasSameTypeSignature = s1.typeSignature =:= s2.typeSignature
+
+      // If s1 and s2 are defined in the same class the owner will be the same
+      // thus s1.overriddenSymbol(S2.owner) will actually return s1.
+      lazy val isOverridden = s1.owner != s2.owner &&
+                              (s1.overriddenSymbol(s2.owner) != pc.NoSymbol ||
+                              s2.overriddenSymbol(s1.owner) != pc.NoSymbol)
+
+      (s1 == s2) || // Fast-path.
+      hasSameName &&
+      isInHiearchy &&
+      (hasSameTypeSignature || isOverridden)
+
+    } getOrElse false
   }
 }

--- a/org.scala.tools.eclipse.search/src/org/scala/tools/eclipse/search/ui/DialogErrorReporter.scala
+++ b/org.scala.tools.eclipse.search/src/org/scala/tools/eclipse/search/ui/DialogErrorReporter.scala
@@ -1,0 +1,21 @@
+package org.scala.tools.eclipse.search.ui
+
+import org.scala.tools.eclipse.search.ErrorReporter
+import org.eclipse.jface.dialogs.MessageDialog
+import org.eclipse.ui.PlatformUI
+
+/**
+ * Uses Eclipse MessageDialog to report errors
+ */
+trait DialogErrorReporter extends ErrorReporter {
+
+  def reportError(msg: String): Unit = {
+    for {
+      wb <- Option(PlatformUI.getWorkbench())
+      window <- Option(wb.getActiveWorkbenchWindow())
+    } {
+      MessageDialog.openError( window.getShell(), "Scala Semantic Search", msg)
+    }
+  }
+
+}


### PR DESCRIPTION
This ties together the Index and SearchPresentationCompiler to
find exact occurrences of a method at a given location.

Tests have been provided that tests that these components play
together nicely but I've kept them simple as the majority of the
tests are written for each of the components (Index, SPC).

Fixes #1001685
