### PR TITLE
Eclipse command for finding occurrence of selection

### DIFF
--- a/org.scala.tools.eclipse.search.tests/src/org/scala/tools/eclipse/search/indexing/IndexTest.scala
+++ b/org.scala.tools.eclipse.search.tests/src/org/scala/tools/eclipse/search/indexing/IndexTest.scala
@@ -176,7 +176,7 @@ class IndexTest {
     val (results, failures) = config.findOccurrences("foo", Set(projectA))
     assertEquals(0, results.size)
     assertEquals(1, failures.size)
-    assertEquals(config.BrokenIndex(projectA), failures.head)
+    assertEquals(BrokenIndex(projectA), failures.head)
 
   }
 
@@ -199,7 +199,7 @@ class IndexTest {
     val (results, failures) = config.findOccurrences("foo", Set(projectA, projectB))
     assertEquals(1, results.size)
     assertEquals(1, failures.size)
-    assertEquals(config.BrokenIndex(projectA), failures.head)
+    assertEquals(BrokenIndex(projectA), failures.head)
 
   }
 

--- a/org.scala.tools.eclipse.search.tests/src/org/scala/tools/eclipse/search/searching/FinderTest.scala
+++ b/org.scala.tools.eclipse.search.tests/src/org/scala/tools/eclipse/search/searching/FinderTest.scala
@@ -10,7 +10,6 @@ import org.junit.Assert._
 import scala.tools.eclipse.javaelements.ScalaCompilationUnit
 import scala.tools.eclipse.EclipseUserSimulator
 import org.eclipse.core.runtime.NullProgressMonitor
-import org.scala.tools.eclipse.search.searching.SourceCreator
 import java.util.concurrent.CountDownLatch
 import org.scala.tools.eclipse.search.FileChangeObserver
 import org.scala.tools.eclipse.search.LogErrorReporter

--- a/org.scala.tools.eclipse.search/META-INF/MANIFEST.MF
+++ b/org.scala.tools.eclipse.search/META-INF/MANIFEST.MF
@@ -9,6 +9,7 @@ Bundle-ActivationPolicy: lazy
 Bundle-Localization: plugin
 Require-Bundle: 
  org.eclipse.core.runtime,
+ org.eclipse.core.filesystem,
  org.eclipse.debug.ui,
  org.eclipse.help,
  org.eclipse.jdt.core;bundle-version="[3.6.0,4.0.0)",

--- a/org.scala.tools.eclipse.search/plugin.xml
+++ b/org.scala.tools.eclipse.search/plugin.xml
@@ -31,4 +31,47 @@
     <startup class="org.scala.tools.eclipse.search.Startup"></startup>
   </extension>
 
+  <!-- Commands -->
+  <extension point="org.eclipse.ui.commands">
+    <category
+              description="Search - Scala"
+              id="org.scala.tools.eclipse.search.commands"
+              name="Search - Scala"/>
+    <command
+             name="Find References of Method"
+             description="Finds all references of a method"
+             categoryId="org.scala.tools.eclipse.search.commands"
+             id="org.scala.tools.eclipse.search.commands.FindReferencesOfMethod"/>
+  </extension>
+
+  <!-- Handlers -->
+  <extension point="org.eclipse.ui.handlers">
+    <handler
+             class="org.scala.tools.eclipse.search.handlers.FindOccurrencesOfMethod"
+             commandId="org.scala.tools.eclipse.search.commands.FindReferencesOfMethod">
+    </handler>
+  </extension>
+
+  <!-- Menus -->
+  <extension point="org.eclipse.ui.menus">
+     <menuContribution locationURI="popup:#CompilationUnitEditorContext?before=additions">
+        <command
+                 commandId="org.scala.tools.eclipse.search.commands.FindReferencesOfMethod"
+                 id="org.scala.tools.eclipse.search.menus.occurrences"
+                 label="Find occurrences"
+                 tooltip="">
+        </command>
+     </menuContribution>
+  </extension>
+
+  <!-- Default Key Bindings -->
+  <extension point="org.eclipse.ui.bindings">
+    <sequenceModifier find="CTRL" replace="COMMAND" platforms="cocoa,carbon" />
+    <key
+         commandId="org.scala.tools.eclipse.search.commands.FindReferencesOfMethod"
+         schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"
+         contextId="scala.tools.eclipse.scalaEditorScope"
+         sequence="CTRL+ALT+SHIFT+R"/>
+  </extension>
+
 </plugin>

--- a/org.scala.tools.eclipse.search/src/org/scala/tools/eclipse/search/ProjectChangeObserver.scala
+++ b/org.scala.tools.eclipse.search/src/org/scala/tools/eclipse/search/ProjectChangeObserver.scala
@@ -9,6 +9,7 @@ import org.eclipse.core.resources.IResourceDeltaVisitor
 import org.eclipse.core.resources.ResourcesPlugin
 import org.eclipse.core.resources.IResource
 import scala.tools.eclipse.ScalaPlugin
+import scala.tools.eclipse.util.Utils.any2optionable
 
 
 /**
@@ -82,7 +83,7 @@ object ProjectChangeObserver {
             }
           }
           case IResourceChangeEvent.PRE_DELETE => {
-            Util.tryCastTo[IProject](ev.getResource).foreach(onDelete)
+            ev.getResource.asInstanceOfOpt[IProject].foreach(onDelete)
           }
         }
       }

--- a/org.scala.tools.eclipse.search/src/org/scala/tools/eclipse/search/UIUtil.scala
+++ b/org.scala.tools.eclipse.search/src/org/scala/tools/eclipse/search/UIUtil.scala
@@ -1,0 +1,14 @@
+package org.scala.tools.eclipse.search
+
+import scala.tools.eclipse.ScalaSourceFileEditor
+import org.eclipse.jface.text.ITextSelection
+import org.eclipse.ui.IEditorPart
+
+object UIUtil {
+  def getSelection(editor: ScalaSourceFileEditor): Option[ITextSelection] = {
+    editor.getSelectionProvider().getSelection() match {
+      case sel: ITextSelection => Some(sel)
+      case _ => None
+    }
+  }
+}

--- a/org.scala.tools.eclipse.search/src/org/scala/tools/eclipse/search/Util.scala
+++ b/org.scala.tools.eclipse.search/src/org/scala/tools/eclipse/search/Util.scala
@@ -10,21 +10,8 @@ import org.eclipse.core.runtime.Path
  * Object that contains various utility methods
  */
 object Util extends HasLogger {
-
   def scalaSourceFileFromIFile(file: IFile): Option[ScalaSourceFile] = {
     val path = file.getFullPath().toOSString()
     ScalaSourceFile.createFromPath(path)
   }
-
-  /**
-   * Convenient way to cast objects. This makes it less painful to use the
-   * Eclipse API's.
-   */
-  def tryCastTo[B : Manifest](x: Any): Option[B] = {
-    x match {
-      case x: B => Some(x)
-      case _ => None
-    }
-  }
-
 }

--- a/org.scala.tools.eclipse.search/src/org/scala/tools/eclipse/search/handlers/FindOccurrencesOfMethod.scala
+++ b/org.scala.tools.eclipse.search/src/org/scala/tools/eclipse/search/handlers/FindOccurrencesOfMethod.scala
@@ -1,0 +1,83 @@
+package org.scala.tools.eclipse.search
+package handlers
+
+import scala.tools.eclipse.logging.HasLogger
+import org.eclipse.core.commands.AbstractHandler
+import org.eclipse.core.commands.ExecutionEvent
+import org.eclipse.core.runtime.IProgressMonitor
+import org.eclipse.core.runtime.IStatus
+import org.eclipse.core.runtime.Status
+import org.eclipse.search.ui.ISearchQuery
+import org.eclipse.search.ui.ISearchResult
+import org.eclipse.search.ui.NewSearchUI
+import org.eclipse.ui.handlers.HandlerUtil
+import org.scala.tools.eclipse.search.ErrorHandlingOption
+import org.scala.tools.eclipse.search.SearchPlugin
+import org.scala.tools.eclipse.search.UIUtil
+import org.scala.tools.eclipse.search.indexing.Index
+import org.scala.tools.eclipse.search.searching.Finder
+import org.scala.tools.eclipse.search.searching.Location
+import org.scala.tools.eclipse.search.searching.Result
+import org.scala.tools.eclipse.search.ui.DialogErrorReporter
+import org.scala.tools.eclipse.search.ui.SearchResult
+import org.scala.tools.eclipse.search.searching.SearchPresentationCompiler
+import org.scala.tools.eclipse.search.indexing.SearchFailure
+import scala.tools.eclipse.util.Utils.any2optionable
+import scala.tools.eclipse.ScalaSourceFileEditor
+
+class FindOccurrencesOfMethod
+  extends AbstractHandler
+     with DialogErrorReporter
+     with HasLogger {
+
+  val finder: Finder = SearchPlugin.finder
+
+  override def execute(event: ExecutionEvent): Object = {
+    for {
+      editor      <- Option(HandlerUtil.getActiveEditor(event)) onEmpty reportError("An editor has to be active")
+      scalaEditor <- editor.asInstanceOfOpt[ScalaSourceFileEditor] onEmpty reportError("Active editor wasn't a Scala editor")
+      selection   <- UIUtil.getSelection(scalaEditor) onEmpty reportError("You need to have a selection")
+    } {
+      val loc = Location(scalaEditor.getInteractiveCompilationUnit, selection.getOffset())
+
+      val (name, isMethod) = scalaEditor.getInteractiveCompilationUnit.withSourceFile { (_, pc) =>
+        val spc = new SearchPresentationCompiler(pc)
+        (spc.nameOfEntityAt(loc), spc.isMethod(loc))
+      }(None, false)
+
+      // Only supports methods for now.
+      if (isMethod) {
+        NewSearchUI.runQueryInBackground(new ISearchQuery(){
+
+          val sr = new SearchResult(this)
+
+          @volatile var hitsCount = 0
+          @volatile var potentialHitsCount = 0
+
+          override def canRerun(): Boolean = false
+          override def canRunInBackground(): Boolean = true
+
+          override def getLabel: String =
+            s"'${name.getOrElse("selection")}' - ${hitsCount} exact matches, $potentialHitsCount potential matches "
+
+          override def run(monitor: IProgressMonitor): IStatus = {
+            finder.occurrencesOfEntityAt(loc)(
+                hit = (r: Result) => {
+                  hitsCount += 1
+                  sr.addMatch(r.toMatch)
+                },
+                potentialHit = _ =>
+                  potentialHitsCount  += 1,
+                errorHandler = (fail: SearchFailure) =>
+                  logger.debug(s"Got an error ${fail}"))
+            Status.OK_STATUS
+          }
+          override def getSearchResult(): ISearchResult = sr
+        })
+      } else reportError("Sorry, find occurrences only supports methods for now")
+    }
+    // According to the Eclipse docs we have to return null.
+    null
+  }
+
+}

--- a/org.scala.tools.eclipse.search/src/org/scala/tools/eclipse/search/indexing/Occurrence.scala
+++ b/org.scala.tools.eclipse.search/src/org/scala/tools/eclipse/search/indexing/Occurrence.scala
@@ -1,6 +1,7 @@
 package org.scala.tools.eclipse.search.indexing
 
 import scala.tools.eclipse.javaelements.ScalaSourceFile
+import org.scala.tools.eclipse.search.searching.Result
 
 /**
  * Represents the various kinds of occurrences that we deal with
@@ -22,6 +23,7 @@ object LuceneFields {
   val OFFSET          = "offset"
   val OCCURRENCE_KIND = "occurrenceKind"
   val PROJECT_NAME    = "project"
+  val LINE_CONTENT    = "lineContent"
 }
 
 /**
@@ -32,7 +34,21 @@ case class Occurrence(
     word: String,
     file: ScalaSourceFile,
     offset: Int, // char offset from beginning of file
-    occurrenceKind: OccurrenceKind) {
+    occurrenceKind: OccurrenceKind,
+    lineContent: String = "") {
+
+  def toResult: Result =
+    Result(file, word, lineContent,offset)
+
+  override def equals(other: Any) = other match {
+    // Don't compare lineCOntent 
+    case o: Occurrence =>
+      word == o.word &&
+      file == o.file &&
+      offset == o.offset &&
+      occurrenceKind == o.occurrenceKind
+    case _ => false
+  }
 
   override def toString = "%s in %s at char %s %s".format(
       word,

--- a/org.scala.tools.eclipse.search/src/org/scala/tools/eclipse/search/indexing/OccurrenceCollector.scala
+++ b/org.scala.tools.eclipse.search/src/org/scala/tools/eclipse/search/indexing/OccurrenceCollector.scala
@@ -47,22 +47,22 @@ object OccurrenceCollector extends HasLogger {
         t match {
 
           case Ident(fun) if !isSynthetic(pc)(t, fun.toString) =>
-            occurrences += Occurrence(fun.toString, file, t.pos.point, Reference)
+            occurrences += Occurrence(fun.toString, file, t.pos.point, Reference, t.pos.lineContent)
 
           case Select(rest,name) if !isSynthetic(pc)(t, name.toString) =>
-            occurrences += Occurrence(name.toString, file, t.pos.point, Reference)
+            occurrences += Occurrence(name.toString, file, t.pos.point, Reference, t.pos.lineContent)
             traverse(rest) // recurse in the case of chained selects: foo.baz.bar
 
           // Method definitions
           case DefDef(mods, name, _, args, _, body) if !isSynthetic(pc)(t, name.toString) =>
-            occurrences += Occurrence(name.toString, file, t.pos.point, Declaration)
+            occurrences += Occurrence(name.toString, file, t.pos.point, Declaration, t.pos.lineContent)
             traverseTrees(mods.annotations)
             traverseTreess(args)
             traverse(body)
 
           // Val's and arguments.
           case ValDef(_, name, tpt, rhs) =>
-            occurrences += Occurrence(name.toString, file, t.pos.point, Declaration)
+            occurrences += Occurrence(name.toString, file, t.pos.point, Declaration, t.pos.lineContent)
             traverse(tpt)
             traverse(rhs)
 

--- a/org.scala.tools.eclipse.search/src/org/scala/tools/eclipse/search/searching/Result.scala
+++ b/org.scala.tools.eclipse.search/src/org/scala/tools/eclipse/search/searching/Result.scala
@@ -1,0 +1,11 @@
+package org.scala.tools.eclipse.search.searching
+
+import scala.tools.eclipse.InteractiveCompilationUnit
+import org.eclipse.search.ui.text.Match
+
+/**
+ * Represents a successful search result.
+ */
+case class Result(cu: InteractiveCompilationUnit, word: String, lineContent: String, offset: Int) {
+  def toMatch: Match = new Match(this, offset, word.length)
+}

--- a/org.scala.tools.eclipse.search/src/org/scala/tools/eclipse/search/searching/SearchPresentationCompiler.scala
+++ b/org.scala.tools.eclipse.search/src/org/scala/tools/eclipse/search/searching/SearchPresentationCompiler.scala
@@ -44,6 +44,24 @@ class SearchPresentationCompiler(val pc: ScalaPresentationCompiler) extends HasL
   }
 
   /**
+   * Checks is a symbols is a method or constructor. This is
+   * needed such that we can restrict the FindOccurrenceOfMethod
+   * to only work for methods until the rest of the entities are
+   * suppored.
+   */
+  def isMethod(loc: Location): Boolean = {
+    loc.cu.withSourceFile({ (sf, pc) =>
+      symbolAt(loc, sf) match {
+        case FoundSymbol(symbol) =>
+          pc.askOption { () =>
+            symbol.isMethod || symbol.isConstructor
+          }.getOrElse(false)
+        case _ => false
+      }
+    })(false)
+  }
+
+  /**
    * Get a comparator for a symbol at a given Location. The Comparator can be
    * used to see if symbols at other locations are the same as this symbol.
    */

--- a/org.scala.tools.eclipse.search/src/org/scala/tools/eclipse/search/ui/DialogErrorReporter.scala
+++ b/org.scala.tools.eclipse.search/src/org/scala/tools/eclipse/search/ui/DialogErrorReporter.scala
@@ -1,18 +1,20 @@
-package org.scala.tools.eclipse.search.ui
+package org.scala.tools.eclipse.search
+package ui
 
 import org.scala.tools.eclipse.search.ErrorReporter
 import org.eclipse.jface.dialogs.MessageDialog
 import org.eclipse.ui.PlatformUI
+import scala.tools.eclipse.logging.HasLogger
 
 /**
  * Uses Eclipse MessageDialog to report errors
  */
-trait DialogErrorReporter extends ErrorReporter {
+trait DialogErrorReporter extends ErrorReporter with HasLogger {
 
   def reportError(msg: String): Unit = {
     for {
-      wb <- Option(PlatformUI.getWorkbench())
-      window <- Option(wb.getActiveWorkbenchWindow())
+      wb     <- Option(PlatformUI.getWorkbench()) onEmpty logger.debug("Couldn'get workbench")
+      window <- Option(wb.getActiveWorkbenchWindow()) onEmpty logger.debug("Couldn'get window")
     } {
       MessageDialog.openError( window.getShell(), "Scala Semantic Search", msg)
     }

--- a/org.scala.tools.eclipse.search/src/org/scala/tools/eclipse/search/ui/EditorMatchAdapter.scala
+++ b/org.scala.tools.eclipse.search/src/org/scala/tools/eclipse/search/ui/EditorMatchAdapter.scala
@@ -1,0 +1,30 @@
+package org.scala.tools.eclipse.search.ui
+
+import org.eclipse.search.ui.text.IEditorMatchAdapter
+import org.eclipse.search.ui.text.AbstractTextSearchResult
+import org.eclipse.ui.IEditorPart
+import org.eclipse.search.ui.text.Match
+import org.scala.tools.eclipse.search.searching.Location
+import org.eclipse.ui.IFileEditorInput
+import org.scala.tools.eclipse.search.searching.Result
+import scala.tools.eclipse.logging.HasLogger
+
+class EditorMatchAdapter extends IEditorMatchAdapter with HasLogger {
+
+  // Returns all matches that are contained in the element shown in the given editor.
+  override def computeContainedMatches(result: AbstractTextSearchResult, editor: IEditorPart): Array[Match] = {
+    val results = result.getElements.map(_.asInstanceOf[Result])
+    editor.getEditorInput() match {
+      case in: IFileEditorInput => results.filter(_.cu.workspaceFile == in.getFile).map(_.toMatch)
+      case _ => Array()
+    }
+  }
+
+  // Determines whether a match should be displayed in the given editor.
+  override def isShownInEditor(m: Match, editor: IEditorPart) = {
+    (m.getElement(), editor.getEditorInput()) match {
+      case (loc: Location, in: IFileEditorInput) => loc.cu.workspaceFile == in.getFile
+      case _ => false
+    }
+  }
+}

--- a/org.scala.tools.eclipse.search/src/org/scala/tools/eclipse/search/ui/FileMatchAdapter.scala
+++ b/org.scala.tools.eclipse.search/src/org/scala/tools/eclipse/search/ui/FileMatchAdapter.scala
@@ -1,0 +1,24 @@
+package org.scala.tools.eclipse.search.ui
+
+import org.eclipse.search.ui.text.IFileMatchAdapter
+import org.eclipse.search.ui.text.AbstractTextSearchResult
+import org.eclipse.core.resources.IFile
+import org.eclipse.search.ui.text.Match
+import org.scala.tools.eclipse.search.searching.Location
+import org.scala.tools.eclipse.search.searching.Result
+
+class FileMatchAdapter extends IFileMatchAdapter {
+
+  // Returns an array with all matches contained in the given file in the given search result.
+  def computeContainedMatches(result: AbstractTextSearchResult, file: IFile): Array[Match] = {
+    val results = result.getElements.map(_.asInstanceOf[Result])
+    results.filter(_.cu.workspaceFile == file).map(_.toMatch)
+  }
+
+  // Returns the file associated with the given element (usually the file the element is contained in).
+  def getFile(element: Object): IFile = {
+    val location = element.asInstanceOf[Result]
+    location.cu.workspaceFile
+  }
+
+}

--- a/org.scala.tools.eclipse.search/src/org/scala/tools/eclipse/search/ui/ResultContentProvider.scala
+++ b/org.scala.tools.eclipse.search/src/org/scala/tools/eclipse/search/ui/ResultContentProvider.scala
@@ -1,0 +1,58 @@
+package org.scala.tools.eclipse.search.ui
+
+import org.scala.tools.eclipse.search.searching.Result
+import org.eclipse.jface.viewers.Viewer
+import scala.tools.eclipse.logging.HasLogger
+import org.eclipse.jface.viewers.ITreeContentProvider
+import org.eclipse.jface.viewers.AbstractTreeViewer
+
+/**
+ * Responsible for telling Eclipse what content to show after a successful
+ * search.
+ */
+class ResultContentProvider(page: SearchResultPage) extends ITreeContentProvider with HasLogger {
+
+  private var input: SearchResult = _
+
+  def elementsChanged(elements: Array[Object]): Unit = {
+    // Performance-wise this can be imporoved ALOT!
+    // see http://javasourcecode.org/html/open-source/eclipse/eclipse-3.5.2/org/eclipse/jdt/internal/ui/search/LevelTreeContentProvider.java.html
+    val viewer = page.view.asInstanceOf[AbstractTreeViewer]
+    viewer.refresh()
+  }
+
+  override def dispose() {
+    input = null
+  }
+
+  override def inputChanged(viewer: Viewer, oldInput: Object, newInput: Object) {
+    if (newInput != null) {
+      if (newInput.isInstanceOf[SearchResult]) {
+        input = newInput.asInstanceOf[SearchResult]
+      } else {
+        logger.debug(s"Expeced SearchResult but got ${newInput}")
+      }
+    }
+  }
+
+  override def getElements(inputElement: Object): Array[Object] = {
+    // This returns the top-level elements, i.e. the filename and the match
+    // count in that file.
+    input.resultsGroupedByFile.map { case (str, seq) => (str, seq.size) }.toArray
+  }
+
+  override def getChildren(parentElement: Object): Array[Object] = {
+    parentElement match {
+      case (x: String, _) =>
+        input.resultsGroupedByFile.get(x).map(_.toArray.map(_.asInstanceOf[Object])).getOrElse(Array[Object]())
+      case _ => Array[Object]()
+    }
+  }
+
+  override def getParent(element: Object): Object = null
+
+  override def hasChildren(element: Object): Boolean = element match {
+    case (x: String, _) => input.resultsGroupedByFile.get(x).fold(false)(_ => true)
+    case _ => false
+  }
+}

--- a/org.scala.tools.eclipse.search/src/org/scala/tools/eclipse/search/ui/ResultLabelProvider.scala
+++ b/org.scala.tools.eclipse.search/src/org/scala/tools/eclipse/search/ui/ResultLabelProvider.scala
@@ -1,0 +1,49 @@
+package org.scala.tools.eclipse.search.ui
+
+import org.eclipse.jface.viewers.LabelProvider
+import org.eclipse.jface.viewers.ViewerCell
+import org.eclipse.jface.viewers.StyledString
+import org.eclipse.jface.viewers.StyledCellLabelProvider
+import org.eclipse.ui.PlatformUI
+import org.eclipse.ui.ISharedImages
+import org.eclipse.jface.resource.JFaceResources
+import org.eclipse.swt.graphics.RGB
+import scala.tools.eclipse.logging.HasLogger
+import org.scala.tools.eclipse.search.searching.Result
+import org.eclipse.jdt.internal.ui.JavaPlugin
+import org.eclipse.ui.part.FileEditorInput
+import org.eclipse.ui.ide.IDE
+import org.scala.tools.eclipse.search.UIUtil
+import scala.tools.eclipse.ScalaImages
+
+/**
+ * Responsible for telling Eclipse how to render the results in the
+ * tree view (i.e. the view that shows the results).
+ */
+class ResultLabelProvider extends StyledCellLabelProvider with HasLogger {
+
+  private final val HIGHLIGHT_COLOR_NAME = "org.scala.tools.eclipse.search"
+  JFaceResources.getColorRegistry().put(HIGHLIGHT_COLOR_NAME, new RGB(206, 204, 247));
+
+  override def update(cell: ViewerCell) {
+
+    val text = new StyledString
+
+    cell.getElement() match {
+      case (str: String, count: Int) =>
+        text.append(str)
+        text.append(" (%s)".format(count), StyledString.COUNTER_STYLER)
+        cell.setImage(ScalaImages.SCALA_FILE.createImage())
+      case result: Result =>
+        val styled = new StyledString(result.lineContent.trim)
+        text.append(styled)
+      case x =>
+        logger.debug(s"Expected content of either a tuple or Result, got: ${x}")
+    }
+
+    cell.setText(text.toString)
+    cell.setStyleRanges(text.getStyleRanges)
+    super.update(cell)
+  }
+
+}

--- a/org.scala.tools.eclipse.search/src/org/scala/tools/eclipse/search/ui/SearchResult.scala
+++ b/org.scala.tools.eclipse.search/src/org/scala/tools/eclipse/search/ui/SearchResult.scala
@@ -5,42 +5,51 @@ import org.eclipse.search.ui.ISearchQuery
 import org.eclipse.search.ui.text.AbstractTextSearchResult
 import org.eclipse.search.ui.text.IEditorMatchAdapter
 import org.eclipse.search.ui.text.IFileMatchAdapter
+import org.scala.tools.eclipse.search.searching.Result
+import org.eclipse.search.ui.text.Match
+import scala.tools.eclipse.ScalaImages
 
 /**
  * Represents the result of executing a search query against Scala
  * files.
  */
-class SearchResult extends AbstractTextSearchResult {
+class SearchResult(query: ISearchQuery) extends AbstractTextSearchResult {
 
   /**
    * An implementation of IEditorMatchAdapter appropriate for this search result.
    */
-  def getEditorMatchAdapter(): IEditorMatchAdapter = ???
+  def getEditorMatchAdapter(): IEditorMatchAdapter = new EditorMatchAdapter
 
   /**
    * An implementation of IFileMatchAdapter appropriate for this search result.
    */
-  def getFileMatchAdapter(): IFileMatchAdapter = ???
+  def getFileMatchAdapter(): IFileMatchAdapter = new FileMatchAdapter
 
   /**
    * The image descriptor for the given ISearchResult.
    */
-  def getImageDescriptor(): ImageDescriptor = ???
+  def getImageDescriptor(): ImageDescriptor = ScalaImages.SCALA_FILE
 
   /**
    * A user readable label for this search result. The label is typically used in the result view
    * and should contain the search query string and number of matches.
    */
-  def getLabel(): String = "Haven't implemented yet"
+  def getLabel(): String = query.getLabel
 
   /**
    * The query that produced this search result.
    */
-  def getQuery(): ISearchQuery = ???
+  def getQuery(): ISearchQuery = query
 
   /**
    * A tooltip to be used when this search result is shown in the UI.
    */
-  def getTooltip(): String = "Haven't implemented yet"
+  def getTooltip(): String = query.getLabel
+
+  def resultsGroupedByFile = {
+    // TODO: Cache this, for speed improvements
+    val res = this.getElements.map(_.asInstanceOf[Result])
+    res.groupBy(_.cu.workspaceFile.getProjectRelativePath().toOSString())
+  }
 
 }

--- a/org.scala.tools.eclipse.search/src/org/scala/tools/eclipse/search/ui/SearchResultPage.scala
+++ b/org.scala.tools.eclipse.search/src/org/scala/tools/eclipse/search/ui/SearchResultPage.scala
@@ -3,37 +3,86 @@ package org.scala.tools.eclipse.search.ui
 import org.eclipse.jface.viewers.TableViewer
 import org.eclipse.jface.viewers.TreeViewer
 import org.eclipse.search.ui.text.AbstractTextSearchViewPage
+import org.eclipse.jface.viewers.IContentProvider
+import org.eclipse.jface.viewers.ILabelProvider
+import org.scala.tools.eclipse.search.searching.Result
+import scala.tools.eclipse.InteractiveCompilationUnit
+import org.eclipse.jface.viewers.Viewer
+import scala.tools.eclipse.logging.HasLogger
+import org.eclipse.jface.viewers.ITreeContentProvider
+import org.eclipse.jface.viewers.StructuredViewer
+import org.eclipse.jface.viewers.IStructuredSelection
+import org.eclipse.jface.viewers.OpenEvent
+import org.eclipse.jface.action.Action
+import org.eclipse.ui.IWorkbenchWindowActionDelegate
+import org.eclipse.ui.IWorkbenchWindow
+import org.eclipse.jdt.internal.ui.JavaPlugin
+import org.eclipse.ui.part.FileEditorInput
+import org.eclipse.ui.ide.IDE
+import org.eclipse.ui.ide.IDE
+import scala.tools.eclipse.util.Utils.any2optionable
+import scala.tools.eclipse.ScalaSourceFileEditor
 
 /**
  * The page that is responsible for displaying the results of executing
  * a scala search query.
  */
-class SearchResultPage extends AbstractTextSearchViewPage {
+class SearchResultPage
+    extends AbstractTextSearchViewPage
+    with HasLogger
+    with DialogErrorReporter {
+
+  // http://javasourcecode.org/html/open-source/eclipse/eclipse-3.5.2/org/eclipse/jdt/internal/ui/search/JavaSearchResultPage.java.html
+
+  val contentProvider = new ResultContentProvider(this)
+  val labelProvider = new ResultLabelProvider
+
+  def view: StructuredViewer = {
+    super.getViewer()
+  }
 
   /**
    *  This method is called whenever all elements have been removed from the view.
    */
-  def clear(): Unit = ???
+  def clear(): Unit = {}
 
   /**
    *  This method is called whenever the set of matches for the given elements changes.
    */
-  def elementsChanged(elements: Array[Object]): Unit = ???
+  def elementsChanged(elements: Array[Object]): Unit = {
+    if (elements != null)
+      contentProvider.elementsChanged(elements)
+  }
 
   /**
    * Invoked if the results are to be shown in a table.
    */
   def configureTableViewer(table: TableViewer): Unit = {
     // TODO: Set up a content provider for the table.
-    ???
+    reportError("Table View is currently not supported")
   }
 
   /**
    * Invoked if the results are to be shown in a tree view
    */
   def configureTreeViewer(tree: TreeViewer): Unit = {
-    // TODO: Set up a content provider for the tree view.
-    ???
+    tree.setContentProvider(contentProvider)
+    tree.setLabelProvider(labelProvider)
   }
 
+  override protected def handleOpen(event: OpenEvent): Unit = {
+    val firstElement = event.getSelection().asInstanceOf[IStructuredSelection].getFirstElement()
+    if (firstElement.isInstanceOf[Result]) {
+      val result = firstElement.asInstanceOf[Result]
+      val page = JavaPlugin.getActivePage()
+      val file = result.cu.workspaceFile
+      val input = new FileEditorInput(file)
+      val desc = IDE.getEditorDescriptor(file.getName())
+      val part = IDE.openEditor(page, input, desc.getId())
+      val editor = part.asInstanceOfOpt[ScalaSourceFileEditor].get
+      editor.selectAndReveal(result.offset, result.word.length)
+    } else {
+      super.handleOpen(event)
+    }
+  }
 }


### PR DESCRIPTION
This commit provides an Eclipse command for finding all
occurrences of the Scala entity that is selected in the
current editor.

Currently just supports methods

Fixes #1001686
