### PR TITLE
Can now find occurrences of apply

### DIFF
--- a/org.scala.tools.eclipse.search.tests/src/org/scala/tools/eclipse/search/searching/SearchPresentationCompilerTest.scala
+++ b/org.scala.tools.eclipse.search.tests/src/org/scala/tools/eclipse/search/searching/SearchPresentationCompilerTest.scala
@@ -145,6 +145,17 @@ class SearchPresentationCompilerTest {
     """} isSameMethod(false)
   }
 
+  @Test def isSameMethod_worksForApply {
+    project.create("WorksForApply.scala") {"""
+      object ObjectA {
+        def a|pply(x: String) = x
+      }
+      object ObjectB {
+        Obje|ctA("test")
+      }
+    """} isSameMethod(true)
+  }
+
   @Test
   def isSameMethod_overriddenCountsAsSame {
     project.create("OverriddenCountsAsSame.scala") {"""

--- a/org.scala.tools.eclipse.search/src/org/scala/tools/eclipse/search/searching/Finder.scala
+++ b/org.scala.tools.eclipse.search/src/org/scala/tools/eclipse/search/searching/Finder.scala
@@ -40,9 +40,9 @@ trait Finder extends ProjectFinder
       val spc = new SearchPresentationCompiler(pc)
       for {
         comparator <- spc.comparator(location) onEmpty reportError(s"Couldn't get comparator based on symbol at ${location.offset} in ${sf.file.path}")
-        name <- spc.nameOfEntityAt(location) onEmpty reportError(s"Couldn't get name of symbol at ${location.offset} in ${sf.file.path}")
+        names <- spc.possibleNamesOfEntityAt(location) onEmpty reportError(s"Couldn't get name of symbol at ${location.offset} in ${sf.file.path}")
       } {
-        val (occurrences, failures) = findOccurrences(name, allScala)
+        val (occurrences, failures) = findOccurrences(names, allScala)
         logger.debug(s"Found ${occurrences.size} potential matches")
         failures.foreach(errorHandler)
         occurrences.foreach { occurrence =>


### PR DESCRIPTION
The Finder could previously not find these occurrences as
the don't appear Apply(Select(apply),...) but rather
Apply(Ident(Foo),..).

I fixed it by making it possible to search for multiple
words when looking for occurrences (this will also be needed
later when searching for aliases). When searching for an apply
invocation i will now search for explicit invocations (i.e. apply)
and implicit invocations (i.e. Foo). So it will search for apply and
the name of the owner of the apply method.

Fixes #1001736
