### PR TITLE
Fix for overloaded method symbols

### DIFF
--- a/org.scala.tools.eclipse.search.tests/src/org/scala/tools/eclipse/search/searching/SearchPresentationCompilerTest.scala
+++ b/org.scala.tools.eclipse.search.tests/src/org/scala/tools/eclipse/search/searching/SearchPresentationCompilerTest.scala
@@ -215,6 +215,50 @@ class SearchPresentationCompilerTest {
     """} isSameMethod(false)
   }
 
+  @Test def isSameMethod_overloaded {
+    val sourceA = project.create("AskOption.scala") {"""
+      class AskOption {
+        def askO|ption(op: () => String): Option[String] = askOption(op, 10000)
+        def askOption(op: () => String, timeout: Int): Option[String] = None
+      }
+    """}
+
+    val sourceB = project.create("AskOptionUser.scala") {"""
+      object AskOptionUser {
+        val a = new AskOption
+        a.askO|ption { () =>
+          "hi there"
+        }
+      }
+    """}
+
+    sourceA.isSameMethodAs(sourceB, true)
+  }
+
+  @Test def isSameMethod_overloadedWithExplicitTypeParam {
+    // Make sure that we ask the compiler for the right tree
+    // in case of overloaded methods where the invocation has
+    // explicit type parameters. See
+    // SearchPresentationComiler.resolveOverloadedSymbol
+    val sourceA = project.create("AskOption.scala") {"""
+      class AskOption {
+        def askO|ption[A](op: () => A): Option[A] = askOption(op, 10000)
+        def askOption[A](op: () => A, timeout: Int): Option[A] = None
+      }
+    """}
+
+    val sourceB = project.create("AskOptionUser.scala") {"""
+      object AskOptionUser {
+        val a = new AskOption
+        a.askO|ption[String] { () =>
+          "hi there"
+        }
+      }
+    """}
+
+    sourceA.isSameMethodAs(sourceB, true)
+  }
+
   @Test
   def isSameMethod_partiallyAppliedMethod {
     project.create("PartiallyApplied.scala") {"""

--- a/org.scala.tools.eclipse.search.tests/src/org/scala/tools/eclipse/search/searching/SourceCreator.scala
+++ b/org.scala.tools.eclipse.search.tests/src/org/scala/tools/eclipse/search/searching/SourceCreator.scala
@@ -60,8 +60,8 @@ trait SourceCreator {
         val spc = new SearchPresentationCompiler(pc)
         spc.comparator(loc1).map { comparator =>
           comparator.isSameAs(loc2) match {
-            case Same => assertEquals(true, expected)
-            case _ => assertEquals(false, expected)
+            case Same => assertEquals(expected, true)
+            case _ => assertEquals(expected, false)
           }
         }.getOrElse(fail("Couldn't get comparator for symbol"))
       }((fail("Couldn't get source file")))


### PR DESCRIPTION
When asking for the type of a position that contains an invocation of
an overloaded method we would sometimes get an overloaded method
symbol from the compiler rather than the symbol of the precise method
that was being invoked.

The problem is that `askTypeAt` only returns the smallest fully attributed
tree that encloses a given position. Consider the following example

``` scala
def askOption[A](op: () => A): Option[A] = askOption(op, 10000)
def askOption[A](op: () => A, timeout: Int): Option[A] = None

askOption { () =>
  ...
}
```

If the position is at the beginning of the `askOption` identifier (the invocation)
then the presentation compiler will only type-check the receiver (the Select node)
and not the arguments and thus will not resolve the overloaded method.

We fix this by asking the compiler to type-check more of the tree using a
RangePosition.

Fixes #38
