### PR TITLE
Fix exception when showing hits for closed project/deleted files

### DIFF
--- a/org.scala.tools.eclipse.search/src/org/scala/tools/eclipse/search/ui/EditorMatchAdapter.scala
+++ b/org.scala.tools.eclipse.search/src/org/scala/tools/eclipse/search/ui/EditorMatchAdapter.scala
@@ -13,9 +13,9 @@ class EditorMatchAdapter extends IEditorMatchAdapter with HasLogger {
 
   // Returns all matches that are contained in the element shown in the given editor.
   override def computeContainedMatches(result: AbstractTextSearchResult, editor: IEditorPart): Array[Match] = {
-    val results = result.getElements.map(_.asInstanceOf[Hit])
+    val hits = result.getElements.map(_.asInstanceOf[Hit])
     editor.getEditorInput() match {
-      case in: IFileEditorInput => results.filter(_.cu.workspaceFile == in.getFile).map(_.toMatch)
+      case in: IFileEditorInput => MatchAdatperHelper.matches(hits, in.getFile)
       case _ => Array()
     }
   }
@@ -23,7 +23,7 @@ class EditorMatchAdapter extends IEditorMatchAdapter with HasLogger {
   // Determines whether a match should be displayed in the given editor.
   override def isShownInEditor(m: Match, editor: IEditorPart) = {
     (m.getElement(), editor.getEditorInput()) match {
-      case (loc: Location, in: IFileEditorInput) => loc.cu.workspaceFile == in.getFile
+      case (hit: Hit, in: IFileEditorInput) => MatchAdatperHelper.existsAndMatches(hit, in.getFile)
       case _ => false
     }
   }

--- a/org.scala.tools.eclipse.search/src/org/scala/tools/eclipse/search/ui/FileMatchAdapter.scala
+++ b/org.scala.tools.eclipse.search/src/org/scala/tools/eclipse/search/ui/FileMatchAdapter.scala
@@ -11,14 +11,23 @@ class FileMatchAdapter extends IFileMatchAdapter {
 
   // Returns an array with all matches contained in the given file in the given search result.
   def computeContainedMatches(result: AbstractTextSearchResult, file: IFile): Array[Match] = {
-    val results = result.getElements.map(_.asInstanceOf[Hit])
-    results.filter(_.cu.workspaceFile == file).map(_.toMatch)
+    val hits = result.getElements.map(_.asInstanceOf[Hit])
+    MatchAdatperHelper.matches(hits, file)
   }
 
   // Returns the file associated with the given element (usually the file the element is contained in).
   def getFile(element: Object): IFile = {
-    val location = element.asInstanceOf[Hit]
-    location.cu.workspaceFile
+    //  Doc: If the element is not associated with a file, 
+    //       this method should return null.
+    //
+    //  So we return null if
+    //    - We don't recognize the object
+    //    - The file has been deleted since the search was executed or
+    //      the project that contains the file is now closed.
+    element match {
+      case hit: Hit => MatchAdatperHelper.getWorkspaceFile(hit).getOrElse(null)
+      case _ => null
+    }
   }
 
 }

--- a/org.scala.tools.eclipse.search/src/org/scala/tools/eclipse/search/ui/MatchAdatperHelper.scala
+++ b/org.scala.tools.eclipse.search/src/org/scala/tools/eclipse/search/ui/MatchAdatperHelper.scala
@@ -1,0 +1,33 @@
+package org.scala.tools.eclipse.search.ui
+
+import org.scala.tools.eclipse.search.searching.Hit
+import org.eclipse.core.resources.IFile
+import org.eclipse.search.ui.text.Match
+import scala.util.Try
+
+object MatchAdatperHelper {
+
+  def matches(hits: Seq[Hit], file: IFile): Array[Match] = {
+    hits.filter(existsAndMatches(_, file)).map(_.toMatch).toArray
+  }
+
+  def existsAndMatches(hit: Hit, file: IFile): Boolean = {
+    (for {
+      hitFile <- getWorkspaceFile(hit)
+      if existsAndProjectIsOpen(hitFile) && existsAndProjectIsOpen(file)
+    } yield hitFile == file) getOrElse false
+  }
+
+  def getWorkspaceFile(hit: Hit): Option[IFile] = {
+    // Accessing hit.cu.workspaceFile will throw an
+    // exception if hit.cu doesn't exist or the
+    // project is closed so we have to check that first.
+    if (hit.cu.exists && hit.cu.scalaProject.underlying.isOpen) Option(hit.cu.workspaceFile) else None
+  }
+
+  def existsAndProjectIsOpen(file: IFile): Boolean = {
+    // if the project is closed, file.exists will also return false
+    file != null && file.exists
+  }
+
+}

--- a/org.scala.tools.eclipse.search/src/org/scala/tools/eclipse/search/ui/SearchResult.scala
+++ b/org.scala.tools.eclipse.search/src/org/scala/tools/eclipse/search/ui/SearchResult.scala
@@ -46,10 +46,12 @@ class SearchResult(query: ISearchQuery) extends AbstractTextSearchResult {
    */
   def getTooltip(): String = query.getLabel
 
-  def resultsGroupedByFile = {
+  def resultsGroupedByFile: Map[String, Array[Hit]] = {
     // TODO: Cache this, for speed improvements
     val res = this.getElements.map(_.asInstanceOf[Hit])
-    res.groupBy(_.cu.workspaceFile.getProjectRelativePath().toOSString())
+
+    res.filter(MatchAdatperHelper.getWorkspaceFile(_).isDefined)
+       .groupBy(_.cu.workspaceFile.getProjectRelativePath().toOSString)
   }
 
 }


### PR DESCRIPTION
A Java Model Exception would be thrown whenever the search view
was showing results from files that no longer existed or files
that belonged to projects that were no longer open.

This also fixes a less serious bug. When performing a search Eclipse
will now corretly show markers in the file that is open if any
results are contained in that file. Before you had to open another
file and return to the original one for the markers to show up.

Fixes #1001741
