### PR TITLE
Find References now supports val/vars

### DIFF
--- a/org.scala.tools.eclipse.search.tests/src/org/scala/tools/eclipse/search/searching/SearchPresentationCompilerTest.scala
+++ b/org.scala.tools.eclipse.search.tests/src/org/scala/tools/eclipse/search/searching/SearchPresentationCompilerTest.scala
@@ -94,13 +94,17 @@ class SearchPresentationCompilerTest {
     """} expectedTypeError
   }
 
+  /**----------------------*
+   * Methods               *
+   * ----------------------*/
+
   @Test
   def isSameMethod_withSameSymbol {
     project.create("WithSameSymbol.scala") {"""
       class WithSameSymbol {
         def re|ve|rse(x: String) = x.reverse
       }
-    """} isSameMethod(true)
+    """} isSame(true)
   }
 
   @Test
@@ -110,7 +114,7 @@ class SearchPresentationCompilerTest {
         def fo|o(x: String) = x
         def bar(x: String) = fo|o(x)
       }
-    """} isSameMethod(true)
+    """} isSame(true)
   }
 
   @Test
@@ -120,7 +124,7 @@ class SearchPresentationCompilerTest {
         def fo|o(x: String) = x
         def bar(x: String) = invalid(fo|o(x))
       }
-    """} isSameMethod(false)
+    """} isSame(false)
   }
 
   @Test
@@ -132,7 +136,7 @@ class SearchPresentationCompilerTest {
       class B {
         def bar(x: String) = (new A).fo|o(x)
       }
-    """} isSameMethod(true)
+    """} isSame(true)
   }
 
   @Test
@@ -142,7 +146,7 @@ class SearchPresentationCompilerTest {
         def ad|dStrings(x: String, y: String) = x + y
         def ad|dInts(x: Int, y: Int) = x + y
       }
-    """} isSameMethod(false)
+    """} isSame(false)
   }
 
   @Test def isSameMethod_worksForApply {
@@ -153,7 +157,7 @@ class SearchPresentationCompilerTest {
       object ObjectB {
         Obje|ctA("test")
       }
-    """} isSameMethod(true)
+    """} isSame(true)
   }
 
   @Test
@@ -165,7 +169,7 @@ class SearchPresentationCompilerTest {
       class B extends A {
         override def fo|o(x: String) = x
       }
-    """} isSameMethod(true)
+    """} isSame(true)
   }
 
   @Test
@@ -177,11 +181,11 @@ class SearchPresentationCompilerTest {
       class B extends A {
         override val fo|o: String = "there"
       }
-    """} isSameMethod(true)
+    """} isSame(true)
   }
 
   @Test
-  def isSameMethod_overriddenVarCountAsSame {
+  def isSameMethod_overriddenVarCountAsSameSetter {
     project.create("OverriddenVarCountsAsSame.scala") {"""
       trait A {
         def fo|o_=(x: String): Unit
@@ -189,7 +193,48 @@ class SearchPresentationCompilerTest {
       abstract class B extends A {
         var f|oo: String
       }
-    """} isSameMethod(true)
+    """} isSame(true)
+  }
+
+  @Test
+  def isSameMethod_overriddenVarCountAsSameGetter {
+    project.create("OverriddenVarCountsAsSame.scala") {"""
+      trait A {
+        def fo|o: String
+      }
+      abstract class B extends A {
+        var f|oo: String
+      }
+    """} isSame(true)
+  }
+
+  @Test
+  def isSameMethod_normalizeSetter {
+    project.create("OverriddenVarCountsAsSame.scala") {"""
+      trait A {
+        def fo|o_=(x: String): Unit
+      }
+      class B(var foo: String) extends A
+      object C {
+        val b = new B("test")
+        b.fo|o = "setting this"
+      }
+    """} isSame(true)
+  }
+
+  @Test
+  def isSameMethod_beCarefulAboutOverriddenSymbols {
+    // A bug I had in a previous version would fail
+    // this test.
+    project.create("BeCarefullAboutOverridden.scala") {"""
+      class A {
+        def f|oo: String = "hi"
+      }
+      class B extends A {
+        def fo|o(x: String): String = x
+        override def foo: String = "bar in B"
+      }
+    """} isSame(false)
   }
 
   @Test
@@ -202,7 +247,7 @@ class SearchPresentationCompilerTest {
         type S = String
         override def fo|o: S = "there"
       }
-    """} isSameMethod(true)
+    """} isSame(true)
   }
 
   @Test
@@ -212,7 +257,7 @@ class SearchPresentationCompilerTest {
         def ad|d(x: String, y: String) = x + y
         def ad|d(x: Int, y: Int) = x + y
       }
-    """} isSameMethod(false)
+    """} isSame(false)
   }
 
   @Test def isSameMethod_overloaded {
@@ -232,7 +277,7 @@ class SearchPresentationCompilerTest {
       }
     """}
 
-    sourceA.isSameMethodAs(sourceB, true)
+    sourceA.isSameAs(sourceB, true)
   }
 
   @Test def isSameMethod_overloadedWithExplicitTypeParam {
@@ -256,7 +301,7 @@ class SearchPresentationCompilerTest {
       }
     """}
 
-    sourceA.isSameMethodAs(sourceB, true)
+    sourceA.isSameAs(sourceB, true)
   }
 
   @Test
@@ -266,7 +311,7 @@ class SearchPresentationCompilerTest {
         def fo|o(x: String): String
         def bar: String => String = fo|o
       }
-    """} isSameMethod(true)
+    """} isSame(true)
   }
 
   @Test
@@ -279,7 +324,7 @@ class SearchPresentationCompilerTest {
       class B extends A {
         def bar = fo|o("test")
       }
-    """} isSameMethod(true)
+    """} isSame(true)
   }
 
   @Test
@@ -291,7 +336,7 @@ class SearchPresentationCompilerTest {
       class B extends A {
         def bar = fo|o("test")
       }
-    """} isSameMethod(true)
+    """} isSame(true)
   }
 
   @Test
@@ -303,7 +348,7 @@ class SearchPresentationCompilerTest {
       class B extends A {
         abstract override def fo|o(x: String): String = "Test"
       }
-    """} isSameMethod(true)
+    """} isSame(true)
   }
 
   @Test
@@ -317,7 +362,7 @@ class SearchPresentationCompilerTest {
           super.f|oo(x)+"Test"
         }
       }
-    """} isSameMethod(true)
+    """} isSame(true)
   }
 
   @Test
@@ -329,7 +374,7 @@ class SearchPresentationCompilerTest {
       class B extends A {
         override def m|e: this.type = this
       }
-    """} isSameMethod(true)
+    """} isSame(true)
   }
 
   @Test
@@ -339,7 +384,7 @@ class SearchPresentationCompilerTest {
         def fo|o(x: String): String = x
         def bar = (new Object).asInstanceOf[A].fo|o("test")
       }
-    """} isSameMethod(true)
+    """} isSame(true)
   }
 
   @Test def isSameMethod_constructorsAreMethodsToo {
@@ -352,7 +397,7 @@ class SearchPresentationCompilerTest {
       class B {
         def foo = ne|w A("test")
       }
-    """} isSameMethod(true)
+    """} isSame(true)
   }
 
   @Test
@@ -366,7 +411,7 @@ class SearchPresentationCompilerTest {
           t|his(x)
         }
       }
-    """} isSameMethod(true)
+    """} isSame(true)
   }
 
   @Test def isSameMethod_selfTypes {
@@ -377,7 +422,7 @@ class SearchPresentationCompilerTest {
       class B { this: A =>
         def bar = fo|o("test")
       }
-    """} isSameMethod(true)
+    """} isSame(true)
   }
 
   @Test
@@ -390,8 +435,124 @@ class SearchPresentationCompilerTest {
       object C {
         def fo|o(x: String) = x
       }
-    """} isSameMethod(true)
+    """} isSame(true)
   }
+
+  /**----------------------*
+   * Vars                  *
+   * ----------------------*/
+
+  @Test
+  def isSameVar_canCompareVars {
+    project.create("CanCompareVars.scala") {"""
+      class A {
+        var var|iable: String = "test"
+        var|iable
+      }
+    """} isSame(true)
+  }
+
+  @Test
+  def isSameVar_canCompareSetters {
+    project.create("CanCompareSetters.scala") {"""
+      class A {
+        var variable: String = "test"
+        var|iable = "foo"
+        var|iable = "bar"
+      }
+    """} isSame(true)
+  }
+
+  @Test
+  def isSameVar_canCompareGetters {
+    project.create("CanCompareGetters.scala") {"""
+      object A {
+        var variable: String = "test"
+      }
+      object B {
+        A.var|iable
+        A.var|iable
+      }
+    """} isSame(true)
+  }
+
+  @Test
+  def isSameVar_canCompareVarAndSetter {
+    project.create("CanCompareVarAndSetter.scala") {"""
+      class A {
+        var vari|able: String = "test"
+        var|iable = "foo"
+      }
+    """} isSame(true)
+  }
+
+  @Test
+  def isSameVar_canCompareVarAndGetter {
+    project.create("CanCompareGetters.scala") {"""
+      object A {
+        var var|iable: String = "test"
+      }
+      object B {
+        A.var|iable
+      }
+    """} isSame(true)
+  }
+
+  @Test
+  def isSameVar_canCompareExplicitSetter {
+    project.create("CanCompareExplicitSetter.scala") {"""
+      object A {
+        var var|iable: String = "test"
+      }
+      object B {
+        A.variab|le_=("foo")
+      }
+    """} isSame(true)
+  }
+
+  /**----------------------*
+   * Vals                  *
+   * ----------------------*/
+
+  @Test
+  def isSameVal_canCompareVals = {
+    project.create("CanCompareVals.scala") {"""
+      class A {
+        val va|lue = "test"
+        val|ue
+      }
+    """} isSame(true)
+  }
+
+  @Test
+  def isSameVal_canCompareGetters = {
+    project.create("CanCompareGetters.scala") {"""
+      object A {
+        val value = "test"
+      }
+      object B {
+        A.val|ue
+        A.val|ue
+      }
+    """} isSame(true)
+  }
+
+  @Test
+  def isSameVal_canCompareValAndGetter = {
+    project.create("CanCompareGetters.scala") {"""
+      object A {
+        val va|lue = "test"
+      }
+      object B {
+        A.val|ue
+        A.value
+      }
+    """} isSame(true)
+  }
+
+  /**----------------------*
+   * Various               *
+   * ----------------------*/
 
   @Test
   def isSameMethod_worksWithSameProject {
@@ -413,7 +574,7 @@ class SearchPresentationCompilerTest {
 
     latch.await(5,java.util.concurrent.TimeUnit.SECONDS)
 
-    sourceA.isSameMethodAs(sourceB)
+    sourceA.isSameAs(sourceB)
 
     p1.delete
     observer.stop
@@ -451,7 +612,7 @@ class SearchPresentationCompilerTest {
 
     latch.await(5,java.util.concurrent.TimeUnit.SECONDS)
 
-    sourceA.isSameMethodAs(sourceB)
+    sourceA.isSameAs(sourceB)
 
     p1.delete
     p2.delete
@@ -502,9 +663,9 @@ class SearchPresentationCompilerTest {
 
     latch.await(5,java.util.concurrent.TimeUnit.SECONDS)
 
-    sourceB.isSameMethodAs(sourceA)
-    sourceC.isSameMethodAs(sourceA)
-    sourceC.isSameMethodAs(sourceB)
+    sourceB.isSameAs(sourceA)
+    sourceC.isSameAs(sourceA)
+    sourceC.isSameAs(sourceB)
 
     p1.delete
     p2.delete

--- a/org.scala.tools.eclipse.search.tests/src/org/scala/tools/eclipse/search/searching/SourceCreator.scala
+++ b/org.scala.tools.eclipse.search.tests/src/org/scala/tools/eclipse/search/searching/SourceCreator.scala
@@ -41,7 +41,7 @@ trait SourceCreator {
      *
      * Note: The document has to be created with two markers (i.e. |)
      */
-    def isSameMethod(expected: Boolean): Unit = {
+    def isSame(expected: Boolean): Unit = {
       unit.withSourceFile { (sf, pc) =>
         val spc = new SearchPresentationCompiler(pc)
         spc.comparator(Location(unit, markers(0))).map { comparator =>
@@ -53,7 +53,7 @@ trait SourceCreator {
       }((fail("Couldn't get source file")))
     }
 
-    def isSameMethodAs(other: ScalaDocument, expected: Boolean = true) = {
+    def isSameAs(other: ScalaDocument, expected: Boolean = true) = {
       val loc1 = Location(unit, markers.head)
       val loc2 = Location(other.unit, other.markers.head)
       unit.withSourceFile { (sf, pc) =>

--- a/org.scala.tools.eclipse.search/plugin.xml
+++ b/org.scala.tools.eclipse.search/plugin.xml
@@ -41,14 +41,14 @@
              name="Find References of Method"
              description="Finds all references of a method"
              categoryId="org.scala.tools.eclipse.search.commands"
-             id="org.scala.tools.eclipse.search.commands.FindReferencesOfMethod"/>
+             id="org.scala.tools.eclipse.search.commands.FindReferences"/>
   </extension>
 
   <!-- Handlers -->
   <extension point="org.eclipse.ui.handlers">
     <handler
-             class="org.scala.tools.eclipse.search.handlers.FindOccurrencesOfMethod"
-             commandId="org.scala.tools.eclipse.search.commands.FindReferencesOfMethod">
+             class="org.scala.tools.eclipse.search.handlers.FindOccurrences"
+             commandId="org.scala.tools.eclipse.search.commands.FindReferences">
     </handler>
   </extension>
 
@@ -56,7 +56,7 @@
   <extension point="org.eclipse.ui.menus">
      <menuContribution locationURI="popup:#CompilationUnitEditorContext?before=additions">
         <command
-                 commandId="org.scala.tools.eclipse.search.commands.FindReferencesOfMethod"
+                 commandId="org.scala.tools.eclipse.search.commands.FindReferences"
                  id="org.scala.tools.eclipse.search.menus.occurrences"
                  label="Find occurrences"
                  tooltip="">
@@ -68,7 +68,7 @@
   <extension point="org.eclipse.ui.bindings">
     <sequenceModifier find="CTRL" replace="COMMAND" platforms="cocoa,carbon" />
     <key
-         commandId="org.scala.tools.eclipse.search.commands.FindReferencesOfMethod"
+         commandId="org.scala.tools.eclipse.search.commands.FindReferences"
          schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"
          contextId="scala.tools.eclipse.scalaEditorScope"
          sequence="CTRL+ALT+SHIFT+R"/>

--- a/org.scala.tools.eclipse.search/src/org/scala/tools/eclipse/search/handlers/FindOccurrences.scala
+++ b/org.scala.tools.eclipse.search/src/org/scala/tools/eclipse/search/handlers/FindOccurrences.scala
@@ -27,7 +27,7 @@ import scala.tools.eclipse.ScalaSourceFileEditor
 import org.scala.tools.eclipse.search.searching.ExactHit
 import org.scala.tools.eclipse.search.searching.PotentialHit
 
-class FindOccurrencesOfMethod
+class FindOccurrences
   extends AbstractHandler
      with HasLogger {
 
@@ -42,13 +42,12 @@ class FindOccurrencesOfMethod
     } {
       val loc = Location(scalaEditor.getInteractiveCompilationUnit, selection.getOffset())
 
-      val (name, isMethod) = scalaEditor.getInteractiveCompilationUnit.withSourceFile { (_, pc) =>
+      val (name, supported) = scalaEditor.getInteractiveCompilationUnit.withSourceFile { (_, pc) =>
         val spc = new SearchPresentationCompiler(pc)
-        (spc.nameOfEntityAt(loc), spc.isMethod(loc))
+        (spc.nameOfEntityAt(loc), spc.canFindReferences(loc))
       }(None, false)
 
-      // Only supports methods for now.
-      if (isMethod) {
+      if (supported) {
         NewSearchUI.runQueryInBackground(new ISearchQuery(){
 
           val sr = new SearchResult(this)

--- a/org.scala.tools.eclipse.search/src/org/scala/tools/eclipse/search/searching/SearchPresentationCompiler.scala
+++ b/org.scala.tools.eclipse.search/src/org/scala/tools/eclipse/search/searching/SearchPresentationCompiler.scala
@@ -18,6 +18,14 @@ trait SymbolComparator {
   def isSameAs(loc: Location): ComparisionResult
 }
 
+object SymbolComparator {
+  def apply(f: Location => ComparisionResult): SymbolComparator = {
+    new SymbolComparator {
+      override def isSameAs(loc: Location) = f(loc)
+    }
+  }
+}
+
 /**
  * Encapsulates PC logic. Makes it easier to control where the compiler data
  * structures are used and thus make sure that we conform to the synchronization
@@ -45,43 +53,53 @@ class SearchPresentationCompiler(val pc: ScalaPresentationCompiler) extends HasL
   }
 
   /**
+   * Used to check if the entity at the given location is something we
+   * can find occurrences of. This is useful until we support all kinds
+   * of entities.
+   */
+  def canFindReferences(loc: Location): Boolean = {
+    loc.cu.withSourceFile({ (sf, pc) =>
+      symbolAt(loc, sf) match {
+        case FoundSymbol(symbol) => pc.askOption { () =>
+          symbol.isVal ||
+          symbol.isMethod ||
+          symbol.isConstructor ||
+          symbol.isVar
+        }.getOrElse(false)
+        case _ => false
+      }
+    })(false)
+  }
+
+  /**
    * The name of the symbol at the given location and all the other
    * valid names for that symbol. For example Foo.apply() and Foo() are
    * both valid names for an invocation of Foo.apply
    */
   def possibleNamesOfEntityAt(loc: Location): Option[List[String]] = {
-    loc.cu.withSourceFile({ (sf, pc) =>
-      symbolAt(loc, sf) match {
-        case FoundSymbol(symbol) =>
-          pc.askOption(() => symbol.nameString).flatMap {
-            case n@"apply" =>
-              // TODO: Should use decodedName #1001723
-              pc.askOption(() => symbol.owner.nameString).map { ownerName =>
-                List(n, ownerName)
-              }
-            case n => Some(List(n))
-          }
-        case _ => None
-      }
-    })(None)
-  }
+    loc.cu.withSourceFile({ (sf, _) =>
+      (symbolAt(loc, sf) match {
+        // TODO: Should use decodedName #1001723
+        case FoundSymbol(symbol) => (pc.askOption { () =>
 
-  /**
-   * Checks is a symbols is a method or constructor. This is
-   * needed such that we can restrict the FindOccurrenceOfMethod
-   * to only work for methods until the rest of the entities are
-   * suppored.
-   */
-  def isMethod(loc: Location): Boolean = {
-    loc.cu.withSourceFile({ (sf, pc) =>
-      symbolAt(loc, sf) match {
-        case FoundSymbol(symbol) =>
-          pc.askOption { () =>
-            symbol.isMethod || symbol.isConstructor
-          }.getOrElse(false)
-        case _ => false
-      }
-    })(false)
+          if (symbol.isVar || symbol.isSetter) {
+            val (setterName, getterName) = if (pc.nme.isSetterName(symbol.name)) {
+              (symbol.name.toString, pc.nme.setterToGetter(symbol.name.toTermName).toString.trim)
+            } else {
+              val n = if(pc.nme.isLocalName(symbol.name)) {
+                pc.nme.localToGetter(symbol.name.toTermName)
+              } else symbol.name.toString
+              (pc.nme.getterToSetter(symbol.name.toTermName).toString.replace(" ",""), n.toString)
+            }
+            List(setterName, getterName)
+
+          } else if (symbol.nameString == "apply") {
+            List(symbol.nameString, symbol.owner.nameString)
+          } else List(symbol.nameString)
+        })
+        case _ => None
+      })
+    })(None)
   }
 
   /**
@@ -89,27 +107,31 @@ class SearchPresentationCompiler(val pc: ScalaPresentationCompiler) extends HasL
    * used to see if symbols at other locations are the same as this symbol.
    */
   def comparator(loc: Location): Option[SymbolComparator] = {
-    loc.cu.withSourceFile({ (sf, pc) =>
+
+    def compare(s1: pc.Symbol, s2: pc.Symbol): Option[Boolean] = pc.askOption { () =>
+      if (s1.isVal || s1.isGetter) isSameVal(s1, s2)
+      else if (s1.isVar || s1.isGetter || s1.isSetter) isSameVar(s1, s2)
+      else if (s1.isMethod) isSameMethod(s1.asMethod, s2)
+      else isSameSymbol(s1, s2)
+    } flatten
+
+    def createComparator(symbol: pc.Symbol) = SymbolComparator { otherLoc =>
+      otherLoc.cu.withSourceFile { (otherSf, otherPc) =>
+        val otherSpc = new SearchPresentationCompiler(otherPc)
+        otherSpc.symbolAt(otherLoc, otherSf) match {
+          case otherSpc.FoundSymbol(symbol2) => (for {
+            imported <- importSymbol(otherSpc)(symbol2)
+            isSame   <- compare(symbol,imported)
+            result   = if(isSame) Same else NotSame
+          } yield result) getOrElse NotSame
+          case _ => PossiblySame
+        }
+      }(PossiblySame)
+    }
+
+    loc.cu.withSourceFile({ (sf, _) =>
       symbolAt(loc, sf) match {
-
-        case FoundSymbol(symbol) => Some(new SymbolComparator {
-          def isSameAs(otherLoc: Location): ComparisionResult = {
-            otherLoc.cu.withSourceFile({ (otherSf, otherPc) =>
-              val otherSpc = new SearchPresentationCompiler(otherPc)
-              otherSpc.symbolAt(otherLoc, otherSf) match {
-                case otherSpc.FoundSymbol(symbol2) =>
-                  (for {
-                    imported   <- importSymbol(otherSpc)(symbol2)
-                    isSame     <- isSameMethod(symbol, imported)
-                  } yield {
-                    if(isSame) Same else NotSame
-                  }) getOrElse NotSame
-                case _ => PossiblySame
-              }
-            })(PossiblySame)
-          }
-        })
-
+        case FoundSymbol(symbol) => Some(createComparator(symbol))
         case _ => None
       }
     })(None)
@@ -269,37 +291,116 @@ class SearchPresentationCompiler(val pc: ScalaPresentationCompiler) extends HasL
   }
 
   /**
-   * Check if symbols `s1` and `s2` are describing the same method. We consider two
-   * methods to be the same if
+   * Check if `s2` is valid reference to the symbol `s1`.
+   *
+   * Given that we merge overridden members we need to consider
+   * that a def may also be a valid reference to a val since a
+   * method can be overridden by a val.
+   *
+   * Example:
+   *
+   *   class A {
+   *     def foo = "A"
+   *   }
+   *   class B extends A {
+   *     override val foo = "B"
+   *   }
+   *
+   * Now if we search for occurrence of B.foo we will at some point
+   * compare an occurrence of A.foo with B.foo.
+   *
+   * @note it should always be called within the Presentation Compiler Thread.
+   */
+  private def isSameVal(s1: pc.Symbol, s2: pc.Symbol): Option[Boolean] = {
+    if (s2.isVal || s2.isGetter) isSameSymbol(s1.getter, s2.getter)
+    else isSameSymbol(s1.getter, s2)
+  }
+
+  /**
+   * Check if `s2` is valid reference to the symbol `s1`.
+   *
+   * Given that we merge overridden members we need to consider
+   * that a def may also be a valid reference to a var since a
+   * var can override a method
+   *
+   * Example:
+   *
+   *   abstract class A {
+   *     def foo: String
+   *     def foo_=(x: String)
+   *   }
+   *   class B extends A {
+   *     var foo = "B"
+   *   }
+   *
+   * @note it should always be called within the Presentation Compiler Thread.
+   */
+  private def isSameVar(s1: pc.Symbol, s2: pc.Symbol): Option[Boolean] = {
+    // S1 can be the underlying field, the setter or the getter.
+    // S2 can be the underlying field, a setter, a getter OR a method.
+    if (s2.isVar || s2.isSetter || s2.isGetter) {
+      isSameSymbol(s1.getter, s2.getter)
+    } else {
+      if (pc.nme.isSetterName(s2.name)) isSameSymbol(s1.setter, s2) else isSameSymbol(s1.getter, s2)
+    }
+  }
+
+  /**
+   * Check if `s2` is a valid reference to the method `s1`.
+   *
+   * Given that we merge overridden members and that methods can be
+   * overridden by methods, vars and vals we need to consider all
+   * three cases.
+   *
+   * See docs of `isSameVar` and `isSameVal` for example of this.
+   *
+   * @note it should always be called within the Presentation Compiler Thread.
+   *
+   */
+  private def isSameMethod(s1: pc.MethodSymbol, s2: pc.Symbol): Option[Boolean] = {
+    // S1 is always a method
+    // S2 can be a be a method, a var or a val. For vars/val it can be the underlying
+    //    field, the getter or the setter.
+    if (pc.nme.isSetterName(s1.name)) {
+      if (s2.isVar || s2.isGetter) isSameSymbol(s1, s2.setter)
+      else isSameSymbol(s1,s2)
+    } else {
+      if (s2.isSetter || s2.isVar || s2.isVal) isSameSymbol(s1, s2.getter)
+      else isSameSymbol(s1,s2)
+    }
+  }
+
+  /**
+   * Check if symbols `s1` and `s2` are describing the same symbol. We consider two
+   * symbols to be the same if
    *
    *  - They have the same name
    *  - s1.owner and s2.owner are in the same hierarchy
    *  - They have the same type signature or one is overriding the other
+   *
+   * Now if the symbols have the same name and are in the same hierarchy but the
+   * type-signature doesn't match we check if one symbol is overriding the other.
+   * The reason for this is that the signature might contain references to this.type.
+   *
+   * In the case of comparing vals or vars the caller of this method has to make
+   * sure the the appropriate symbols are compared, e.g. that both S1 and S2
+   * are setters.
    */
-  private def isSameMethod(s1: pc.Symbol, s2: pc.Symbol): Option[Boolean] = {
+  private def isSameSymbol(s1: pc.Symbol, s2: pc.Symbol): Option[Boolean] = {
     pc.askOption { () =>
 
       lazy val isInHiearchy = s1.owner.isSubClass(s2.owner) ||
                               s2.owner.isSubClass(s1.owner)
 
-      lazy val hasSameName = {
-        def getName(s: pc.Symbol)= {
-          if (pc.nme.isSetterName(s.name))
-            pc.nme.setterToGetter(s.name.toTermName)
-          else if(pc.nme.isLocalName(s.name))
-            pc.nme.localToGetter(s.name.toTermName)
-          else s.name
-        }
-        getName(s1) == getName(s2)
-      }
+      lazy val hasSameName = s1.name == s2.name
 
       lazy val hasSameTypeSignature = s1.typeSignature =:= s2.typeSignature
 
       // If s1 and s2 are defined in the same class the owner will be the same
       // thus s1.overriddenSymbol(S2.owner) will actually return s1.
       lazy val isOverridden = s1.owner != s2.owner &&
-                             (s1.overriddenSymbol(s2.owner) != pc.NoSymbol ||
-                              s2.overriddenSymbol(s1.owner) != pc.NoSymbol)
+                             (s1.overriddenSymbol(s2.owner) == s2 ||
+                              s2.overriddenSymbol(s1.owner) == s1)
 
       (s1 == s2) || // Fast-path.
       hasSameName &&


### PR DESCRIPTION
It's now possible to find references to vals and vars

When searching for references to vals/vars we take into account
that there are more than one symbol associated with a val or var.
Vals will generate a symbol for the underlying field and a symbol
for the accessor method (getter). Vars will generate a symbol for
the underlying field, for the getter, and setter methods.

Setter methods can be invoked explicitly i.e. `foo.bar_=(42)` so
when we search for a var we also extend the search to include any
explicit calls to the setter.

Fixes #1001679
