### PR TITLE
Check if a project exists before collecting referenced/referencing projects

### DIFF
--- a/org.scala.tools.eclipse.search/src/org/scala/tools/eclipse/search/searching/ProjectFinder.scala
+++ b/org.scala.tools.eclipse.search/src/org/scala/tools/eclipse/search/searching/ProjectFinder.scala
@@ -28,13 +28,15 @@ class ProjectFinder {
       }
 
       all
-    } else Set()
+    } else Set.empty
   }
 
   private def refs(project: IProject): Seq[IProject] = {
-    val referenced  = project.getReferencedProjects
-    val referencing = project.getReferencingProjects
-    (referenced ++ referencing)
+    if(project.exists()) {
+      val referenced  = project.getReferencedProjects
+      val referencing = project.getReferencingProjects
+      (referenced ++ referencing)
+    }
+    else Seq.empty
   }
-
 }


### PR DESCRIPTION
Fix #1001752
