### PR TITLE
Use decoded names

### DIFF
--- a/org.scala.tools.eclipse.search.tests/src/org/scala/tools/eclipse/search/searching/SearchPresentationCompilerTest.scala
+++ b/org.scala.tools.eclipse.search.tests/src/org/scala/tools/eclipse/search/searching/SearchPresentationCompilerTest.scala
@@ -561,6 +561,41 @@ class SearchPresentationCompilerTest {
     """} isSame(true)
   }
 
+  /**------------------------*
+   * possibleNamesOfEntityAt *
+   * ------------------------*/
+
+  @Test
+  def possibleNamesOfEntityAt_worksForVarDefinition = {
+    project.create("PossibleNamesOfEnityAtWorksForGetter.scala") {"""
+      class A {
+        var variab|le: String = "Test"
+      }
+    """} expectedNames(List("variable_=","variable"))
+  }
+
+  @Test
+  def possibleNamesOfEntityAt_worksForSetter = {
+    project.create("PossibleNamesOfEnityAtWorksForSetter.scala") {"""
+      class A {
+        var variab|le: String = "Test"
+        var|iable = "Testing"
+      }
+    """} expectedNames(List("variable_=", "variable"))
+  }
+
+  @Test
+  def possibleNamesOfEntityAt_worksForApply = {
+    project.create("PossibleNamesOfEnityAtWorksForApply.scala") {"""
+      object A {
+        def apply(x: String) = x
+      }
+      object Using {
+        A.appl|y("test")
+      }
+    """} expectedNames(List("apply","A"))
+  }
+
   /**----------------------*
    * Various               *
    * ----------------------*/

--- a/org.scala.tools.eclipse.search.tests/src/org/scala/tools/eclipse/search/searching/SourceCreator.scala
+++ b/org.scala.tools.eclipse.search.tests/src/org/scala/tools/eclipse/search/searching/SourceCreator.scala
@@ -21,6 +21,14 @@ trait SourceCreator {
       } (fail("Couldn't get Scala source file"))
     }
 
+    def expectedNames(names: List[String]): Unit = {
+      unit.withSourceFile { (sf, pc) =>
+        val spc = new SearchPresentationCompiler(pc)
+        val foundnames = spc.possibleNamesOfEntityAt(Location(unit, markers.head))
+        assertEquals(names, foundnames.getOrElse(Nil))
+      } (fail("Couldn't get Scala source file"))
+    }
+
     def expectedNoSymbol: Unit = {
       unit.withSourceFile { (sf, pc) =>
         val spc = new TestSearchPresentationCompiler(pc)

--- a/org.scala.tools.eclipse.search/src/org/scala/tools/eclipse/search/indexing/OccurrenceCollector.scala
+++ b/org.scala.tools.eclipse.search/src/org/scala/tools/eclipse/search/indexing/OccurrenceCollector.scala
@@ -46,23 +46,23 @@ object OccurrenceCollector extends HasLogger {
       override def traverse(t: Tree) {
         t match {
 
-          case Ident(fun) if !isSynthetic(pc)(t, fun.toString) =>
-            occurrences += Occurrence(fun.toString, file, t.pos.point, Reference, t.pos.lineContent)
+          case Ident(name) if !isSynthetic(pc)(t) =>
+            occurrences += Occurrence(name.decodedName.toString, file, t.pos.point, Reference, t.pos.lineContent)
 
-          case Select(rest,name) if !isSynthetic(pc)(t, name.toString) =>
-            occurrences += Occurrence(name.toString, file, t.pos.point, Reference, t.pos.lineContent)
+          case Select(rest,name) if !isSynthetic(pc)(t) =>
+            occurrences += Occurrence(name.decodedName.toString, file, t.pos.point, Reference, t.pos.lineContent)
             traverse(rest) // recurse in the case of chained selects: foo.baz.bar
 
           // Method definitions
-          case DefDef(mods, name, _, args, _, body) if !isSynthetic(pc)(t, name.toString) =>
-            occurrences += Occurrence(name.toString, file, t.pos.point, Declaration, t.pos.lineContent)
+          case DefDef(mods, name, _, args, _, body) if !isSynthetic(pc)(t) =>
+            occurrences += Occurrence(name.decodedName.toString, file, t.pos.point, Declaration, t.pos.lineContent)
             traverseTrees(mods.annotations)
             traverseTreess(args)
             traverse(body)
 
           // Val's and arguments.
           case ValDef(_, name, tpt, rhs) =>
-            occurrences += Occurrence(name.toString, file, t.pos.point, Declaration, t.pos.lineContent)
+            occurrences += Occurrence(name.decodedName.toString, file, t.pos.point, Declaration, t.pos.lineContent)
             traverse(tpt)
             traverse(rhs)
 
@@ -76,7 +76,7 @@ object OccurrenceCollector extends HasLogger {
   }
 
   private def isSynthetic(pc: ScalaPresentationCompiler)
-                         (tree: pc.Tree, name: String): Boolean = {
+                         (tree: pc.Tree): Boolean = {
     tree.pos == pc.NoPosition
   }
 


### PR DESCRIPTION
Rather than just using the nameString of a symbol we now use the
decoded names. E.g. euqals is now '==' instead of '$eq$eq'

Fixes #1001723
