### PR TITLE
Search jobs can be canceled and show progress

### DIFF
--- a/org.scala.tools.eclipse.search.tests/src/org/scala/tools/eclipse/search/searching/FinderTest.scala
+++ b/org.scala.tools.eclipse.search.tests/src/org/scala/tools/eclipse/search/searching/FinderTest.scala
@@ -68,7 +68,7 @@ class FinderTest {
     indexer.indexProject(project.scalaProject)
 
     @volatile var results = 0
-    finder.occurrencesOfEntityAt(Location(sourceA.unit, sourceA.markers.head)) { loc =>
+    finder.occurrencesOfEntityAt(Location(sourceA.unit, sourceA.markers.head), new NullProgressMonitor) { loc =>
       results += 1
       hitLatch.countDown
     }
@@ -108,7 +108,7 @@ class FinderTest {
     indexer.indexProject(project.scalaProject)
 
     @volatile var results = 0
-    finder.occurrencesOfEntityAt(Location(sourceA.unit, sourceA.markers.head)) { loc =>
+    finder.occurrencesOfEntityAt(Location(sourceA.unit, sourceA.markers.head), new NullProgressMonitor) { loc =>
       results += 1
       hitLatch.countDown
     }
@@ -147,11 +147,11 @@ class FinderTest {
 
     @volatile var resultsForGetter = 0
     @volatile var resultsForSetter = 0
-    finder.occurrencesOfEntityAt(Location(sourceA.unit, sourceA.markers(0))) { loc =>
+    finder.occurrencesOfEntityAt(Location(sourceA.unit, sourceA.markers(0)), new NullProgressMonitor) { loc =>
       resultsForGetter += 1
       hitLatch.countDown
     }
-    finder.occurrencesOfEntityAt(Location(sourceA.unit, sourceA.markers(1))) { loc =>
+    finder.occurrencesOfEntityAt(Location(sourceA.unit, sourceA.markers(1)), new NullProgressMonitor) { loc =>
       resultsForSetter += 1
       hitLatch.countDown
     }
@@ -198,7 +198,7 @@ class FinderTest {
     indexer.indexProject(project2.scalaProject)
 
     @volatile var results = 0
-    finder.occurrencesOfEntityAt(Location(sourceA.unit, sourceA.markers.head)) { loc =>
+    finder.occurrencesOfEntityAt(Location(sourceA.unit, sourceA.markers.head), new NullProgressMonitor) { loc =>
       results += 1
       hitLatch.countDown
     }
@@ -260,7 +260,7 @@ class FinderTest {
 
     @volatile var hits = 0
     @volatile var failures = 0
-    finder.occurrencesOfEntityAt(Location(sourceA.unit, sourceA.markers.head))(
+    finder.occurrencesOfEntityAt(Location(sourceA.unit, sourceA.markers.head), new NullProgressMonitor)(
       hit = _ => {
         hits += 1
         hitLatch.countDown
@@ -311,7 +311,7 @@ class FinderTest {
 
     @volatile var hits = 0
     @volatile var potentialHits = 0
-    finder.occurrencesOfEntityAt(Location(sourceA.unit, sourceA.markers.head))(
+    finder.occurrencesOfEntityAt(Location(sourceA.unit, sourceA.markers.head), new NullProgressMonitor)(
       hit = loc => {
         hits += 1
         hitLatch.countDown

--- a/org.scala.tools.eclipse.search/src/org/scala/tools/eclipse/search/handlers/FindOccurrences.scala
+++ b/org.scala.tools.eclipse.search/src/org/scala/tools/eclipse/search/handlers/FindOccurrences.scala
@@ -26,6 +26,7 @@ import scala.tools.eclipse.util.Utils.any2optionable
 import scala.tools.eclipse.ScalaSourceFileEditor
 import org.scala.tools.eclipse.search.searching.ExactHit
 import org.scala.tools.eclipse.search.searching.PotentialHit
+import scala.tools.eclipse.javaelements.ScalaSourceFile
 
 class FindOccurrences
   extends AbstractHandler
@@ -59,10 +60,10 @@ class FindOccurrences
           override def canRunInBackground(): Boolean = true
 
           override def getLabel: String =
-            s"'${name.getOrElse("selection")}' - ${hitsCount} exact matches, $potentialHitsCount potential matches. Total ${hitsCount+potentialHitsCount} "
+            s"'${name.getOrElse("selection")}' - ${hitsCount} exact matches, $potentialHitsCount potential matches. Total ${hitsCount+potentialHitsCount}"
 
           override def run(monitor: IProgressMonitor): IStatus = {
-            finder.occurrencesOfEntityAt(loc)(
+            finder.occurrencesOfEntityAt(loc, monitor)(
                 hit = (r: ExactHit) => {
                   hitsCount += 1
                   sr.addMatch(r.toMatch)


### PR DESCRIPTION
The search jobs now show their progress by means of a
total percentage of the occurrences that have to be type-checked and
show which file is being type-checked right now.

Jobs can now also be stopped.

Fixes #1001737
