### PR TITLE
Fixing the OccurrenceCollectorTest for Scala 2.11.x

### DIFF
--- a/org.scala.tools.eclipse.search.tests/src/org/scala/tools/eclipse/search/indexing/OccurrenceCollectorTest.scala
+++ b/org.scala.tools.eclipse.search.tests/src/org/scala/tools/eclipse/search/indexing/OccurrenceCollectorTest.scala
@@ -107,8 +107,9 @@ class OccurrenceCollectorTest {
     doWithOccurrencesInUnit("org", "example", "ConstructorInvocations.scala") { occurrences =>
       // we expect 3 here because the constructors created by the compiler calls super.<init>.
       // The compiler generates a constructor for the class and the companion object.
-      val x = occurrenceFor("<init>", occurrences).filter(_.occurrenceKind == Reference)
-      assertEquals("Should find 3 constructors", 3, x.size)
+      val r =  occurrenceFor("<init>", occurrences)
+      val x = r.filter(o => o.occurrenceKind == Reference && o.offset == 84 )
+      assertEquals("Should find 1 constructors invocation", 1, x.size)
     }
   }
 


### PR DESCRIPTION
There is a slight difference between Scala 2.10.x and 2.11.x.

In Scala 2.11.x calls that are placed inside of constructors
that are generated by the compiler have NoPosition as their pos.
(It's a bit weird that they had a position in Scala 2.10.x
anyway since they are synthetic.)

This takes care of this edge case by being more specific about
what kind of occurrence we expect in the test; this should be
reasonbale since we don’t know how to deal with
synthetic symbols yet anyway.

NOTE: There tests are rewritten to match the style of the other
tests (i.e. using source in strings with markers) so please ignore
the magic number 84 when reviewing; it will be removed later
anyway.
