### PR TITLE
Can now distinguish between local vals/vars

### DIFF
--- a/org.scala.tools.eclipse.search.tests/src/org/scala/tools/eclipse/search/searching/SearchPresentationCompilerTest.scala
+++ b/org.scala.tools.eclipse.search.tests/src/org/scala/tools/eclipse/search/searching/SearchPresentationCompilerTest.scala
@@ -390,6 +390,22 @@ class SearchPresentationCompilerTest {
   }
 
   @Test
+  def isSameMethod_canDistinguishBetweenLocalMethods {
+    project.create("CanDistinguishBetweenLocalVals.scala") {"""
+      class A {
+        def foo = {
+          def |testDef = ""
+        }
+      }
+      class B {
+        def foo = {
+          def |testDef = ""
+        }
+      }
+    """} isSame(false)
+  }
+
+  @Test
   def isSameMethod_canHandleSubclasses {
     project.create("CanHandleSubclasses.scala") {"""
       class A {
@@ -609,6 +625,23 @@ class SearchPresentationCompilerTest {
       }"""} isSame(true)
   }
 
+  @Test
+  def isSameVar_canDistinguishBetweenLocalVars {
+    project.create("CanDistinguishBetweenLocalVars.scala") {"""
+      class A {
+        def foo = {
+          var |testVar = ""
+        }
+      }
+
+      class b {
+        def foo = {
+          var |testVar = ""
+        }
+      }
+    """} isSame(false)
+  }
+
   /**----------------------*
    * Vals                  *
    * ----------------------*/
@@ -634,6 +667,22 @@ class SearchPresentationCompilerTest {
         A.val|ue
       }
     """} isSame(true)
+  }
+
+  @Test
+  def isSameVar_canDistinguishBetweenLocalVals {
+    project.create("CanDistinguishBetweenLocalVals.scala") {"""
+      class A {
+        def foo = {
+          val |testVal = ""
+        }
+      }
+      class B {
+        def foo = {
+          val |testVal = ""
+        }
+      }
+    """} isSame(false)
   }
 
   /**------------------------*

--- a/org.scala.tools.eclipse.search/src/org/scala/tools/eclipse/search/searching/SearchPresentationCompiler.scala
+++ b/org.scala.tools.eclipse.search/src/org/scala/tools/eclipse/search/searching/SearchPresentationCompiler.scala
@@ -172,7 +172,8 @@ class SearchPresentationCompiler(val pc: ScalaPresentationCompiler) extends HasL
   def comparator(loc: Location): Option[SymbolComparator] = {
 
     def compare(s1: pc.Symbol, s2: pc.Symbol): Option[Boolean] = pc.askOption { () =>
-      if (isValOrVar(s1)) isSameValOrVar(s1, s2)
+      if (s1.isLocal || s2.isLocal) isSameSymbol(s1,s2)
+      else if (isValOrVar(s1)) isSameValOrVar(s1, s2)
       else if (s1.isMethod) isSameMethod(s1.asMethod, s2)
       else isSameSymbol(s1, s2)
     } flatten


### PR DESCRIPTION
The problem was that we're unifying val/var fields by always
comparing the getter symbol. The getter symbol of a local val/var
is NoSymbol, hence it would always return true, since
NoSymbol == NoSymbol.

The fix is simple. If it's a local val/var we need to treat it
differently than a val/var field, and simply compare the using the
isSameSymbol logic.

Fixes #1001775
