### PR TITLE
Change junit bundle name in manifest

### DIFF
--- a/org.scala.tools.eclipse.search.tests/META-INF/MANIFEST.MF
+++ b/org.scala.tools.eclipse.search.tests/META-INF/MANIFEST.MF
@@ -8,7 +8,7 @@ Fragment-Host: org.scala.tools.eclipse.search
 Bundle-RequiredExecutionEnvironment: J2SE-1.5
 Require-Bundle: org.scala-ide.scala.library,
  org.eclipse.equinox.weaving.aspectj,
- org.junit4;bundle-version="4.5.0",
+ org.junit;bundle-version="4.5.0",
  org.scala-ide.sdt.core,
  org.eclipse.equinox.ds
 Import-Package: scala.tools.eclipse.testsetup,


### PR DESCRIPTION
This makes sure that we can compile the tests inside of
Eclipse on Indigo as well as Juno/Kepler.
