### PR TITLE
1001810 Fix Exception for project closure that contained closed project

### DIFF
--- a/org.scala.tools.eclipse.search/src/org/scala/tools/eclipse/search/searching/ProjectFinder.scala
+++ b/org.scala.tools.eclipse.search/src/org/scala/tools/eclipse/search/searching/ProjectFinder.scala
@@ -27,12 +27,12 @@ class ProjectFinder {
         all = all ++ news.toSet
       }
 
-      all
+      all filter ( _.isOpen )
     } else Set.empty
   }
 
   private def refs(project: IProject): Seq[IProject] = {
-    if(project.exists()) {
+    if(project.isOpen) {
       val referenced  = project.getReferencedProjects
       val referencing = project.getReferencingProjects
       (referenced ++ referencing)


### PR DESCRIPTION
When asking for the closure of a project where one of the of the
projects in the dependency chain was closed an exception would
be thrown.

This is now fixed and I added a test that failed before the
fix but works now

Fixes #1001810
