### PR TITLE
Workaround for race condition in symbol importer

### DIFF
--- a/org.scala.tools.eclipse.search/src/org/scala/tools/eclipse/search/searching/SearchPresentationCompiler.scala
+++ b/org.scala.tools.eclipse.search/src/org/scala/tools/eclipse/search/searching/SearchPresentationCompiler.scala
@@ -389,8 +389,11 @@ class SearchPresentationCompiler(val pc: ScalaPresentationCompiler) extends HasL
     // otherwise it would access thread unsafe members in spc.pc when importing the symbol
     // into pc.
     spc.pc.askOption { () =>
-      s.initialize
-      s.ownerChain.foreach(_.initialize)
+      def fullyInitialize(thisSym: spc.pc.Symbol): Unit = {
+        spc.pc.definitions.fullyInitializeSymbol(thisSym)
+        thisSym.sourceModule.initialize
+      }
+      (s :: s.ownerChain) foreach (fullyInitialize)
     } onEmpty (logger.debug("Timed out on initializing symbol before import"))
 
     pc.askOption { () =>


### PR DESCRIPTION
Looks like the symbol importer module isn't thread-safe. In particular, before
importing a symbol from one presentation compiler to another, we need to make
sure the symbol's owner chain, and all companion's symbols are fully
initialized.

Fixes #1001826
