### PR TITLE
Disabled members' inspector in Type Hierarchy view

### DIFF
--- a/org.scala.tools.eclipse.search/src/org/scala/tools/eclipse/search/ui/TypeHierarchyView.scala
+++ b/org.scala.tools.eclipse.search/src/org/scala/tools/eclipse/search/ui/TypeHierarchyView.scala
@@ -100,7 +100,11 @@ class TypeHierarchyView extends ViewPart with HasLogger {
         leafLabel = "No Sub-types"
     ))
 
-    // Configure the Inspector view
+    // disabled as displaying of members isn't yet implemented
+    // addInspectorView(parent)
+  }
+
+  private def addInspectorView(parent: Composite): Unit = {
     val inspectLabel = new Label(parent, SWT.NONE)
     inspectLabel.setText("Inspector")
     inspectLabel.setLayoutData(new GridData(GridData.GRAB_HORIZONTAL | GridData.HORIZONTAL_ALIGN_FILL))


### PR DESCRIPTION
The logic for filling the inspector view isn't yet implemented, hence the
inspector view is disabled now.

Re #1001877
