### PR TITLE
Fixed source compatibility with latest Scala IDE master

### DIFF
--- a/org.scala.tools.eclipse.search.tests/src/org/scala/tools/eclipse/search/searching/SourceCreator.scala
+++ b/org.scala.tools.eclipse.search.tests/src/org/scala/tools/eclipse/search/searching/SourceCreator.scala
@@ -24,7 +24,7 @@ trait SourceCreator {
           entity.name
         }
         assertEquals(nameOpt, name)
-      } (fail("Couldn't get Scala source file"))
+      } getOrElse (fail("Couldn't get Scala source file"))
     }
 
     def expectedDisplayName(nameOpt: Option[String]): Unit = {
@@ -34,7 +34,7 @@ trait SourceCreator {
           entity.displayName
         }
         assertEquals(nameOpt, name)
-      } (fail("Couldn't get Scala source file"))
+      } getOrElse (fail("Couldn't get Scala source file"))
     }
 
     def expectedNames(names: List[String]): Unit = {
@@ -42,7 +42,7 @@ trait SourceCreator {
         val spc = new SearchPresentationCompiler(pc)
         val foundnames = spc.entityAt(Location(unit, markers.head)).right.toOption.flatten map (_.alternativeNames)
         assertEquals(names, foundnames.getOrElse(Nil))
-      } (fail("Couldn't get Scala source file"))
+      } getOrElse (fail("Couldn't get Scala source file"))
     }
 
     def expectedSupertypes(expectedNames: String*): Unit = {
@@ -55,7 +55,7 @@ trait SourceCreator {
         }
         val names = entity.get.supertypes.map(_.name)
         assertEquals(expectedNames, names)
-      }(fail("Couldn't get Scala source file"))
+      } getOrElse (fail("Couldn't get Scala source file"))
     }
 
     def expectedDeclarationNamed(expected: String*): Unit = {
@@ -63,21 +63,21 @@ trait SourceCreator {
         val spc = new SearchPresentationCompiler(pc)
         val occ = spc.declarationContaining(Location(unit, markers.head)).right.toOption.flatten
         assertEquals(List(expected:_*), occ.map( e => List(e.name)).getOrElse(Nil))
-      } (fail("Couldn't get Scala source file"))
+      } getOrElse (fail("Couldn't get Scala source file"))
     }
 
     def expectedNoSymbol: Unit = {
       unit.withSourceFile { (sf, pc) =>
         val spc = new TestSearchPresentationCompiler(pc)
         assertTrue(spc.isNoSymbol(Location(unit, markers.head)))
-      } (fail("Couldn't get Scala source file"))
+      } getOrElse (fail("Couldn't get Scala source file"))
     }
 
     def expectedTypeError: Unit = {
       unit.withSourceFile { (sf, pc) =>
         val spc = new TestSearchPresentationCompiler(pc)
         assertTrue(spc.isTypeError(Location(unit, markers.head)))
-      } (fail("Couldn't get Scala source file"))
+      } getOrElse (fail("Couldn't get Scala source file"))
     }
 
     /**
@@ -94,7 +94,7 @@ trait SourceCreator {
           case Same => assertEquals(expected, true)
           case _ => assertEquals(expected, false)
         }
-      }((fail("Couldn't get source file")))
+      } getOrElse ((fail("Couldn't get source file")))
     }
 
     def isSameAs(other: ScalaDocument, expected: Boolean = true) = {
@@ -106,7 +106,7 @@ trait SourceCreator {
           case Same => assertEquals(expected, true)
           case _ => assertEquals(expected, false)
         }
-      }((fail("Couldn't get source file")))
+      } getOrElse ((fail("Couldn't get source file")))
     }
 
     def allOccurrences: Seq[Occurrence] = {

--- a/org.scala.tools.eclipse.search/src/org/scala/tools/eclipse/search/handlers/FindOccurrences.scala
+++ b/org.scala.tools.eclipse.search/src/org/scala/tools/eclipse/search/handlers/FindOccurrences.scala
@@ -59,9 +59,9 @@ class FindOccurrences
             startSearch(entity, scalaScope)
           } else reporter.reportError("Sorry, that kind of entity isn't supported yet.")
         } getOrElse(reporter.reportError("Couldn't recognize the enity of the selection"))
-      }()
+      }
     }
-
+    
     null // According to the Eclipse docs we have to return null.
   }
 
@@ -97,5 +97,4 @@ class FindOccurrences
       override def getSearchResult(): ISearchResult = sr
     })
   }
-
 }

--- a/org.scala.tools.eclipse.search/src/org/scala/tools/eclipse/search/indexing/OccurrenceCollector.scala
+++ b/org.scala.tools.eclipse.search/src/org/scala/tools/eclipse/search/indexing/OccurrenceCollector.scala
@@ -39,7 +39,7 @@ object OccurrenceCollector extends HasLogger {
         pcompiler.withParseTree(source) { tree =>
           Success(findOccurrences(pcompiler)(file, tree)): Try[Seq[Occurrence]]
         }
-      })(failedWithSF)
+      }) getOrElse (failedWithSF)
     } else noFileError
   }
 

--- a/org.scala.tools.eclipse.search/src/org/scala/tools/eclipse/search/searching/Finder.scala
+++ b/org.scala.tools.eclipse.search/src/org/scala/tools/eclipse/search/searching/Finder.scala
@@ -55,7 +55,7 @@ class Finder(index: Index, reporter: ErrorReporter) extends HasLogger {
     loc.cu.withSourceFile { (sf, pc) =>
       val spc = new SearchPresentationCompiler(pc)
       spc.entityAt(loc)
-    }(Left(CantLoadFile))
+    } getOrElse (Left(CantLoadFile))
   }
 
   /**
@@ -92,19 +92,15 @@ class Finder(index: Index, reporter: ErrorReporter) extends HasLogger {
     def getTypeEntity(hit: Hit): Option[TypeEntity] = {
       hit.cu.withSourceFile { (sf,pc) =>
         val spc = new SearchPresentationCompiler(pc)
-        for {
-          declEntity <- spc.declarationContaining(Location(hit.cu, hit.offset)).right.toOption.flatten //TODO: Report error
-          typeEntity <- declEntity match {
-            // A type can reference it-self in it's super-types so we have this
-            // guard to make sure that it doesn't list itself as a sub-type.
-            // See test 'FinderTest.findAllSubclassesIgnoresTypeConstructorArguments'
-            case x: TypeEntity if x.name != entity.name && !alreadyReportedNames.contains(x.name) =>
-              alreadyReportedNames.append(x.name)
-              Some(x)
-            case _ => None
-          }
-        } yield typeEntity
-      }(None)
+        val maybeEntity = spc.declarationContaining(Location(hit.cu, hit.offset)).right.toOption.flatten
+        //TODO: Report error
+        maybeEntity match {
+          case Some(x: TypeEntity) if x.name != entity.name && !alreadyReportedNames.contains(x.name) =>
+            alreadyReportedNames.append(x.name)
+            x
+          case None => null
+        }
+      }
     }
 
     // Given a hit where the `entity` is used in a super-type position

--- a/org.scala.tools.eclipse.search/src/org/scala/tools/eclipse/search/searching/SearchPresentationCompiler.scala
+++ b/org.scala.tools.eclipse.search/src/org/scala/tools/eclipse/search/searching/SearchPresentationCompiler.scala
@@ -214,7 +214,7 @@ class SearchPresentationCompiler(val pc: ScalaPresentationCompiler) extends HasL
           case _ => Right(None)
         }
       }
-    }(Left(CantLoadFile))
+    } getOrElse (Left(CantLoadFile))
   }
 
   /**
@@ -239,7 +239,7 @@ class SearchPresentationCompiler(val pc: ScalaPresentationCompiler) extends HasL
         } yield result) getOrElse NotSame
         case _ => PossiblySame
       }
-    }(PossiblySame)
+    } getOrElse (PossiblySame)
   }
 
   /**
@@ -271,7 +271,7 @@ class SearchPresentationCompiler(val pc: ScalaPresentationCompiler) extends HasL
           logger.debug(err)
           NotTypeable
         })
-    }(NotTypeable)
+    } getOrElse (NotTypeable)
   }
 
   /**


### PR DESCRIPTION
Source compatibility with Scala IDE master was broken since
scalaide/scalaide@cf73ce8a4c01c97a476f13e6af5f2237895e30dc
