### PR TITLE
Work around test failures in 2.11.0-M8, due to SI-8205

### DIFF
--- a/org.scala.tools.eclipse.search/src/org/scala/tools/eclipse/search/indexing/Index.scala
+++ b/org.scala.tools.eclipse.search/src/org/scala/tools/eclipse/search/indexing/Index.scala
@@ -309,7 +309,7 @@ trait Index extends HasLogger {
     persist(PATH, o.file.workspaceFile.getProjectRelativePath().toPortableString())
     persist(OFFSET, o.offset.toString)
     persist(OCCURRENCE_KIND, o.occurrenceKind.toString)
-    persist(LINE_CONTENT, o.lineContent.toString)
+    persist(LINE_CONTENT, o.lineContent)
     persist(IS_IN_SUPER_POSITION, o.isInSuperPosition.toString)
     persist(PROJECT_NAME, project.getName)
 

--- a/org.scala.tools.eclipse.search/src/org/scala/tools/eclipse/search/indexing/OccurrenceCollector.scala
+++ b/org.scala.tools.eclipse.search/src/org/scala/tools/eclipse/search/indexing/OccurrenceCollector.scala
@@ -5,6 +5,10 @@ import scala.tools.eclipse.javaelements.ScalaSourceFile
 import scala.tools.eclipse.logging.HasLogger
 import scala.util._
 import scala.tools.eclipse.javaelements.ScalaCompilationUnit
+import scala.reflect.internal.util.Position
+import scala.reflect.internal.util.SourceFile
+import scala.reflect.internal.util.NoSourceFile
+import scala.reflect.internal.Chars
 
 /**
  * Used to parse and traverse the parse tree of a compilation unit finding
@@ -43,6 +47,17 @@ object OccurrenceCollector extends HasLogger {
     } else noFileError
   }
 
+  // TODO : remove once we have the fix to SI-8205 (Scala PR
+  // 3427)
+  @deprecated("This should be removed after PR 3247 is released", since="0.2.1")
+  private def altLineContent(p: Position): String = {
+    val (l,s) = (p.line, p.source)
+      if (l == 0 || p.source == NoSourceFile) "" else {
+        s.content drop s.lineToOffset(l-1) takeWhile (c => !Chars.isLineBreakChar(c.toChar)) mkString ""
+      }
+  }
+
+
   private def findOccurrences(pc: ScalaPresentationCompiler)
                              (file: ScalaCompilationUnit, tree: pc.Tree): Seq[Occurrence] = {
     import pc._
@@ -54,7 +69,7 @@ object OccurrenceCollector extends HasLogger {
       override def traverse(t: Tree) {
 
         // Avoid passing the same arguments all over.
-        def mkOccurrence = Occurrence(_: String, file, t.pos.point, _: OccurrenceKind, t.pos.lineContent, isSuper)
+        def mkOccurrence = Occurrence(_: String, file, t.pos.point, _: OccurrenceKind, altLineContent(t.pos), isSuper)
 
         t match {
 


### PR DESCRIPTION
The compiler fix is in https://github.com/scala/scala/pull/3427

In the meantime, to have at least one Scala-search commit that builds on the
2.11.0-M8 release, this reinstates the old SourceFile.lineToString.
