### PR TITLE
Longer timeout and better assertion messages.

### DIFF
--- a/org.scala.tools.eclipse.search.tests/src/org/scala/tools/eclipse/search/IndexJobManagerTest.scala
+++ b/org.scala.tools.eclipse.search.tests/src/org/scala/tools/eclipse/search/IndexJobManagerTest.scala
@@ -15,6 +15,7 @@ import org.eclipse.core.resources.IProject
 import org.scalaide.core.ScalaPlugin
 
 class IndexJobManagerTest {
+  final val TimeOut = 60000 //ms
 
   import SDTTestUtils._
   import IndexJobManagerTest._
@@ -57,28 +58,28 @@ class IndexJobManagerTest {
   @Test
   def canProgramaticallyStartAnIndexingJob() {
     // Precondition
-    assertTrue(project.underlying.isOpen())
+    assertTrue("Project is open", project.underlying.isOpen())
 
     // Event
     indexManager.startIndexing(project.underlying)
 
     // Result
-    assertTrue(indexManager.isIndexing(project.underlying))
+    assertTrue("Project is indexing", indexManager.isIndexing(project.underlying))
   }
 
   @Test
   def canProgramaticallyStopAnIndexingJob() {
     // Precondition
-    assertTrue(project.underlying.isOpen())
-    assertFalse(indexManager.isIndexing(project.underlying))
+    assertTrue("Project is open", project.underlying.isOpen())
+    assertFalse("Project is not indexing", indexManager.isIndexing(project.underlying))
     indexManager.startIndexing(project.underlying)
-    assertTrue(indexManager.isIndexing(project.underlying))
+    assertTrue("Project is indexing", indexManager.isIndexing(project.underlying))
 
     // Event
     indexManager.stopIndexing(project.underlying)
 
     // Result
-    assertFalse(indexManager.isIndexing(project.underlying))
+    assertFalse("Project is not indexing", indexManager.isIndexing(project.underlying))
   }
 
   @Test
@@ -91,8 +92,8 @@ class IndexJobManagerTest {
     })
 
     // preconditions
-    assertTrue(project.underlying.isOpen())
-    assertFalse(indexManager.isIndexing(project.underlying))
+    assertTrue("Project is open", project.underlying.isOpen())
+    assertFalse("Project is not indexing", indexManager.isIndexing(project.underlying))
 
     // event
     project.underlying.close(monitor)
@@ -100,7 +101,7 @@ class IndexJobManagerTest {
     latch.await(EVENT_DELAY, java.util.concurrent.TimeUnit.SECONDS)
 
     // reaction
-    assertTrue(indexManager.isIndexing(project.underlying))
+    assertTrue("Project is indexing", indexManager.isIndexing(project.underlying))
     observer.stop
   }
 
@@ -120,7 +121,7 @@ class IndexJobManagerTest {
     latch.await(EVENT_DELAY, java.util.concurrent.TimeUnit.SECONDS)
 
     // reaction
-    assertTrue(indexManager.isIndexing(p.underlying))
+    assertTrue("Project is indexing", indexManager.isIndexing(p.underlying))
 
     observer.stop
   }
@@ -135,17 +136,17 @@ class IndexJobManagerTest {
     })
 
     // precondition
-    assertTrue(project.underlying.isOpen())
+    assertTrue("Project is open", project.underlying.isOpen())
     indexManager.startIndexing(project.underlying)
-    assertTrue(indexManager.isIndexing(project.underlying))
+    assertTrue("Project is indexing", indexManager.isIndexing(project.underlying))
 
     // event
     project.underlying.close(monitor)
     latch.await(EVENT_DELAY, java.util.concurrent.TimeUnit.SECONDS)
 
     // reaction
-    assertFalse(project.underlying.isOpen())
-    assertFalse(indexManager.isIndexing(project.underlying))
+    assertFalse("Project is not open", project.underlying.isOpen())
+    assertFalse("Project is not indexing", indexManager.isIndexing(project.underlying))
     observer.stop
   }
 
@@ -171,14 +172,14 @@ class IndexJobManagerTest {
     createdLatch.await(EVENT_DELAY, java.util.concurrent.TimeUnit.SECONDS)
 
     // preconditions
-    assertTrue(indexManager.isIndexing(p.underlying))
+    assertTrue("Project is indexing", indexManager.isIndexing(p.underlying))
 
     // event
     p.underlying.delete(true, monitor)
     deletedLatch.await(EVENT_DELAY, java.util.concurrent.TimeUnit.SECONDS)
 
     // expected
-    assertFalse(indexManager.isIndexing(p.underlying))
+    assertFalse("Project is not indexing", indexManager.isIndexing(p.underlying))
     observer.stop
   }
 
@@ -218,19 +219,19 @@ class IndexJobManagerTest {
     // has been indexed. Instead until the index has been created on disc, as
     // we know that will happen once it has indexed the file. We wait no longer
     // than 10 seconds.
-    SDTTestUtils.waitUntil(10000)(indexer.index.location(p.underlying).toFile.exists)
+    SDTTestUtils.waitUntil(TimeOut)(indexer.index.location(p.underlying).toFile.exists)
 
-    assertTrue(indexer.index.location(p.underlying).toFile.exists)
+    assertTrue("Index file exists", indexer.index.location(p.underlying).toFile.exists)
 
     // event
     p.underlying.delete(true, monitor)
     deletedLatch.await(EVENT_DELAY, java.util.concurrent.TimeUnit.SECONDS)
 
     // wait until the index has been removed
-    SDTTestUtils.waitUntil(10000)(!indexer.index.location(p.underlying).toFile.exists)
+    SDTTestUtils.waitUntil(TimeOut)(!indexer.index.location(p.underlying).toFile.exists)
 
     // expected
-    assertFalse(indexer.index.location(p.underlying).toFile.exists)
+    assertFalse("Index file does not exist", indexer.index.location(p.underlying).toFile.exists)
     observer.stop
   }
 }

--- a/org.scala.tools.eclipse.search.tests/src/org/scala/tools/eclipse/search/searching/ProjectFinderTest.scala
+++ b/org.scala.tools.eclipse.search.tests/src/org/scala/tools/eclipse/search/searching/ProjectFinderTest.scala
@@ -13,6 +13,7 @@ import java.util.concurrent.CountDownLatch
 import org.eclipse.core.resources.IProject
 
 class ProjectFinderTest {
+  final val TimeOut = 60000 //ms
 
   import ProjectFinderTest._
   import ProjectFinder._
@@ -57,7 +58,7 @@ class ProjectFinderTest {
     // mean that the getReferencedProjects and getReferencingProjects are
     // initialized properly yet. Aparrently. If we remove this block
     // the conditions below will fail.
-    SDTTestUtils.waitUntil(10000)(setupIsReady)
+    SDTTestUtils.waitUntil(TimeOut)(setupIsReady)
 
     assertEquals(0, projectA.getReferencedProjects().size)
     assertEquals(2, projectA.getReferencingProjects().size) // A and C


### PR DESCRIPTION
This test fails regularly under load. 10s may not be enough on a busy
machine.
