### PR TITLE
Issue/check index 112

### DIFF
--- a/org.scala.tools.eclipse.search/src/org/scala/tools/eclipse/search/jobs/ProjectIndexJob.scala
+++ b/org.scala.tools.eclipse.search/src/org/scala/tools/eclipse/search/jobs/ProjectIndexJob.scala
@@ -62,20 +62,17 @@ class ProjectIndexJob private (
   private def removed(f: IFile): Unit =
     changedResources.put(f, Removed)
 
-  @volatile var observer: Observing = _
-  @volatile var checkIndex = true
+  @volatile
+  private var observer: Observing = FileChangeObserver(project)(
+    onChanged = changed,
+    onAdded = added,
+    onRemoved = removed)
+
+  @volatile
+  private var checkIndex = true
 
   private def projectIsOpenAndExists: Boolean = {
     project.underlying.exists() && project.underlying.isOpen
-  }
-
-  private def setup(): Unit = {
-    observer = FileChangeObserver(project)(
-      onChanged = changed,
-      onAdded = added,
-      onRemoved = removed
-    )
-    checkIndex = true
   }
 
   private def ensureValidIndex(): Unit = {
@@ -178,7 +175,6 @@ object ProjectIndexJob extends HasLogger {
     logger.debug("Started ProjectIndexJob for " + sp.underlying.getName)
 
     val job = new ProjectIndexJob(indexer, sp, interval, onStopped)
-    job.setup()
     job.setSystem(true) // don't show in the UI
     job.setPriority(Job.LONG)
     job

--- a/org.scala.tools.eclipse.search/src/org/scala/tools/eclipse/search/jobs/ProjectIndexJob.scala
+++ b/org.scala.tools.eclipse.search/src/org/scala/tools/eclipse/search/jobs/ProjectIndexJob.scala
@@ -179,7 +179,7 @@ object ProjectIndexJob extends HasLogger {
 
     val job = new ProjectIndexJob(indexer, sp, interval, onStopped)
     job.setup()
-//    job.setSystem(true) // don't show in the UI
+    job.setSystem(true) // don't show in the UI
     job.setPriority(Job.LONG)
     job
   }


### PR DESCRIPTION
- Move index checking on project open. If an index becomes corrupt, it needs a project re-open to clean and restart.
- Modified tests accordingly.
- hide index jobs from the UI.

Fix #112.