### PR TITLE
Style search matches to be more pleasant. Highlight the matched word.

### DIFF
--- a/org.scala.tools.eclipse.search/src/org/scala/tools/eclipse/search/ui/ResultLabelProvider.scala
+++ b/org.scala.tools.eclipse.search/src/org/scala/tools/eclipse/search/ui/ResultLabelProvider.scala
@@ -13,6 +13,7 @@ import org.eclipse.ui.PlatformUI
 import org.scala.tools.eclipse.search.searching.Certain
 import org.scala.tools.eclipse.search.searching.Hit
 import org.scala.tools.eclipse.search.searching.Uncertain
+import org.eclipse.jdt.internal.ui.JavaPluginImages
 
 /**
  * Responsible for telling Eclipse how to render the results in the
@@ -40,14 +41,21 @@ class ResultLabelProvider extends StyledCellLabelProvider with HasLogger {
         text.append(" (%s)".format(count), StyledString.COUNTER_STYLER)
         cell.setImage(ScalaImages.SCALA_FILE.createImage())
 
-      case LineNode(Certain(Hit(_,_,line, _))) =>
+      case LineNode(Certain(Hit(_, word, line, _))) =>
         val styled = new StyledString(line.trim)
         text.append(styled)
+        text.setStyle(line.trim.indexOf(word), word.length, StyledString.DECORATIONS_STYLER)
+        val image = JavaPluginImages.get(JavaPluginImages.IMG_OBJS_SEARCH_OCCURRENCE)
+        cell.setImage(image)
 
-      case LineNode(Uncertain(Hit(_,_,line,_))) =>
+
+      case LineNode(Uncertain(Hit(_, word, line, _))) =>
         val styled = new StyledString(line.trim)
         text.append(styled)
+        text.setStyle(line.trim.indexOf(word), word.length, StyledString.DECORATIONS_STYLER)
         text.append(" - Potential match", StyledString.QUALIFIER_STYLER)
+        val image = JavaPluginImages.get(JavaPluginImages.IMG_OBJS_SEARCH_OCCURRENCE)
+        cell.setImage(image)
 
       case x =>
         logger.debug(s"Expected content of either a tuple or Confidence[Hit], got: ${x}")


### PR DESCRIPTION
A bit more professional view of search results.

The search word is highlighted, and there's a little image next to each search result.
<img width="442" alt="screen shot 2016-03-01 at 21 21 54" src="https://cloud.githubusercontent.com/assets/133742/13440721/b3532a96-dff3-11e5-80cb-2849895ec5a8.png">
